### PR TITLE
Track site visits and time spent on sites

### DIFF
--- a/examples/example_data.json
+++ b/examples/example_data.json
@@ -10,6 +10,12 @@
 		{
 			"origin":"https://dev.to",
 			"isMonetized":true,
+			"originVisitData":{
+				"timeSpentAtOrigin": 8731882,
+				"numberOfVisits": 3,
+				"dateOfFirstVisit": "2020-05-01",
+				"dateOfMostRecentVisit": "2020-06-02"
+			},
 			"paymentPointerMap":{
 				"$ilp.uphold.com/24HhrUGG7ekn":{
 					"paymentPointer":"$ilp.uphold.com/24HhrUGG7ekn",
@@ -26,6 +32,12 @@
 		{
 			"origin":"https://www.twitch.tv",
 			"isMonetized":true,
+			"originVisitData":{
+				"timeSpentAtOrigin": 4723893,
+				"numberOfVisits": 2,
+				"dateOfFirstVisit": "2020-05-15",
+				"dateOfMostRecentVisit": "2020-05-27"
+			},
 			"paymentPointerMap":{
 				"$spsp.coil.com/twitch/nasa":{
 					"paymentPointer":"$spsp.coil.com/twitch/nasa",
@@ -52,6 +64,12 @@
 		{
 			"origin":"https://sdog.netlify.app",
 			"isMonetized":true,
+			"originVisitData":{
+				"timeSpentAtOrigin": 4567890218492,
+				"numberOfVisits": 300,
+				"dateOfFirstVisit": "2020-01-01",
+				"dateOfMostRecentVisit": "2020-06-02"
+			},
 			"paymentPointerMap":{
 				"$ilp.uphold.com/DWhyhLRG7E4Q":{
 					"paymentPointer":"$ilp.uphold.com/DWhyhLRG7E4Q",

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
 			"js": [
 				"src/data/WebMonetizationAsset.js",
 				"src/data/AkitaPaymentPointerData.js",
+				"src/data/AkitaOriginVisitData.js",
 				"src/data/AkitaOriginData.js",
 				"src/data/storage.js",
 				"src/content_main.js"

--- a/src/data/AkitaOriginData.js
+++ b/src/data/AkitaOriginData.js
@@ -11,11 +11,15 @@
 class AkitaOriginData {
 	origin = null;
 	isMonetized = false;
-	// The type of paymentPointerMap is: Object<AkitaPaymentPointerData>
+	// The type of each entry in paymentPointerMap is: AkitaPaymentPointerData
 	paymentPointerMap = {};
+
+	// The type of originVisitData is: AkitaOriginVisitData
+	originVisitData = null;
 
 	constructor(origin) {
 		this.origin = origin;
+		this.originVisitData = new AkitaOriginVisitData();
 	}
 
 	/**
@@ -36,6 +40,12 @@ class AkitaOriginData {
 			);
 		}
 
+		// Add deserialization for originVisitData
+		const originVisitDataDeserialized = AkitaOriginVisitData.fromObject(akitaOriginDataObject.originVisitData);
+		if (originVisitDataDeserialized !== null) {
+			newOriginData.originVisitData = originVisitDataDeserialized;
+		}
+
 		return newOriginData;
 	}
 
@@ -45,7 +55,7 @@ class AkitaOriginData {
 	 *	assetCode?: String,
 	 *	assetScale?: Number,
 	 *	amount?: Number
-	 * }} monetizationObject
+	 * }} paymentData
 	 *	 This object may be created, or a Web Monetization event detail object can be used.
 	 *	 Pass in an object with just a paymentPointer to register a payment pointer for
 	 *	 the current website. Payment pointer should be validated first.
@@ -74,7 +84,21 @@ class AkitaOriginData {
 				this.paymentPointerMap[paymentPointer].addAsset(assetCode, Number(amount), Number(assetScale));
 			}
 		}
+	}
 
-		return this;
+	/**
+	 * Update visit data for the origin.
+	 */
+	updateVisitData() {
+		this.originVisitData.updateVisitData();
+	}
+
+	/**
+	 * Update time spent at the origin.
+	 * 
+	 * @param {Number} recentTimeSpent The time spent at the origin in a session.
+	 */
+	addTimeSpent(recentTimeSpent = 0) {
+		this.originVisitData.addTimeSpent(recentTimeSpent);
 	}
 }

--- a/src/data/AkitaOriginVisitData.js
+++ b/src/data/AkitaOriginVisitData.js
@@ -1,0 +1,95 @@
+/**
+ * Holds visit data for an origin.
+ * 
+ * Refer to originVisitData in example_data.json for examples.
+ * 
+ * Visit data includes:
+ *   - amount of time spent at origin since using Akita (in milliseconds)
+ *   - number of visits recorded in Akita
+ *   - date of first visit recorded in Akita (format: YYYY-MM-DD)
+ *   - date of most recent visit recorded in Akita (format: YYYY-MM-DD)
+ */
+class AkitaOriginVisitData {
+	timeSpentAtOrigin = 0; // time in milliseconds
+	numberOfVisits = 0;
+	dateOfFirstVisit = "";
+	dateOfMostRecentVisit = "";
+
+	/**
+	 * This function takes an object with the same properties as AkitaOriginVisitData,
+	 * i.e. an AkitaOriginVisitData instance which has been stored and loaded from browser storage,
+	 * and copies the object's properties over to an AkitaOriginVisitData instance.
+	 *
+	 * @param {Object} akitaOriginVisitDataObject an object with the same properties as an AkitaOriginVisitData object.
+	 * @return {AkitaOriginVisitData} the input object as an instance of the AkitaOriginVisitData class.
+	 */
+	static fromObject(akitaOriginVisitDataObject) {
+		let newOriginVisitData = null;
+
+		if (akitaOriginVisitDataObject !== null) {
+			newOriginVisitData = new AkitaOriginVisitData();
+			newOriginVisitData.timeSpentAtOrigin = akitaOriginVisitDataObject.timeSpentAtOrigin;
+			newOriginVisitData.numberOfVisits = akitaOriginVisitDataObject.numberOfVisits;
+			newOriginVisitData.dateOfFirstVisit = akitaOriginVisitDataObject.dateOfFirstVisit;
+			newOriginVisitData.dateOfMostRecentVisit = akitaOriginVisitDataObject.dateOfMostRecentVisit;
+		}
+		
+		return newOriginVisitData;
+	}
+
+	/**
+	 * Update the total time spent by adding the recent time to the total.
+	 * 
+	 * @param {Number} recentTimeSpentAtOrigin The new amount of time spent at the origin.
+	 *   This number is a Double, since performance.now() is used to construct this number.
+	 */
+	addTimeSpent(recentTimeSpentAtOrigin = 0) {
+		// Since recentTimeSpentAtOrigin is a double, we take the floor of the value.
+		this.timeSpentAtOrigin += Math.floor(recentTimeSpentAtOrigin);
+	}
+
+	/**
+	 * Update the visit data.
+	 */
+	updateVisitData() {
+		this.numberOfVisits += 1;
+		this.dateOfMostRecentVisit = this.getCurrentDateAsYYYYMMDD();
+
+		if (this.dateOfFirstVisit === "") {
+			// We haven't already stored the date of first visit
+			this.dateOfFirstVisit = this.dateOfMostRecentVisit;
+		}
+	}
+
+	/**
+	 * Return the current date formatted as YYYY-MM-DD.
+	 * 
+	 * @return {Number} The current date.
+	 */
+	getCurrentDateAsYYYYMMDD() {
+		const DASH = '-';
+		const currentDate = new Date();
+		const currentYear = currentDate.getFullYear();
+		const currentMonth = this.formatNumberAsDateString(currentDate.getMonth() + 1); // +1 since month is 0-indexed in javascript :(
+		const currentDay = this.formatNumberAsDateString(currentDate.getDay());
+
+		const dateString = currentYear + DASH + currentMonth + DASH + currentDay;
+
+		return dateString;
+	}
+
+	/**
+	 * Prepend the number with a zero if its value is between
+	 * zero and ten, so that it is compatible in date strings.
+	 * 
+	 * e.g. If number = 6, return "06"
+	 * 
+	 * @param {Number} number Value to format as a date number.
+	 * @return The formatted number. 
+	 */
+	formatNumberAsDateString(number) {
+		if (number < 10 && number > 0) {
+			return "0" + number;
+		}
+	}
+}

--- a/src/data/AkitaPaymentPointerData.js
+++ b/src/data/AkitaPaymentPointerData.js
@@ -4,7 +4,7 @@
  */
 class AkitaPaymentPointerData {
 	paymentPointer = null;
-	// The type of sentAssetsMap is: Object<WebMonetizationAsset>
+	// The type of each entry in sentAssetsMap is: WebMonetizationAsset
 	sentAssetsMap = {};
 
 	constructor(paymentPointer) {

--- a/src/data/WebMonetizationAsset.js
+++ b/src/data/WebMonetizationAsset.js
@@ -15,7 +15,9 @@ class WebMonetizationAsset {
 	assetScale = 0;
 	assetCode = null;
 
-	constructor(assetCode) {
+	constructor(amount, assetScale, assetCode) {
+		this.amount = amount;
+		this.assetScale = assetScale;
 		this.assetCode = assetCode;
 	}
 
@@ -28,10 +30,14 @@ class WebMonetizationAsset {
 	 * @return {WebMonetizationAsset} the input object as an instance of the WebMonetizationAsset class.
 	 */
 	static fromObject(webMonetizationAsset) {
-		const newThis = new WebMonetizationAsset(webMonetizationAsset.assetCode);
-		newThis.amount = webMonetizationAsset.amount;
-		newThis.assetScale = webMonetizationAsset.assetScale;
-		return newThis;
+		const newWebMonetizationAsset =
+			new WebMonetizationAsset(
+				webMonetizationAsset.amount,
+				webMonetizationAsset.assetScale,
+				webMonetizationAsset.assetCode
+			);
+
+		return newWebMonetizationAsset;
 	}
 
 	/**


### PR DESCRIPTION
fixes: #3 , fixes: #7 

- track time spent on webpage
   - add time spent on site every 2 seconds
- track number of visits to webpage
- store date of first visit to webpage
- store date of most recent visit to webpage

NOTES
- may need to keep an eye out for time spent on sites - seems to be working, but `setInterval()` seems a bit sketchy
- tested on Firefox and Chrome - both working