### PR TITLE
Add various calculations to use in UI display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Akita Icon](assets/icon_128x128.png)
 
 # Akita
-A browser extension that gives you insight into your involvement with web monetization.
+A browser extension that gives you insight into your involvement with Web Monetization.
 
 Akita shows you your top visited sites, how much time you’re spending on them, and whether those sites are monetized or not.
 
@@ -32,4 +32,4 @@ Naming projects can be pretty challenging. We spent a good chunk of time coming 
 
 The Akita is a Japanese dog breed known for its loyalty and dedication. It's also quite fluffy. We were drawn to "Akita" because of the values the breed represents, as those characteristics are what we want to embrace with our project. Through Akita and Web Monetization, we want to enable mutual loyalty and dedication between content creators/websites and their users.
 
-We were also very inspired by the story of [Hachikō](https://en.wikipedia.org/wiki/Hachik%C5%8D) - a dog of immense loyalty. Hachikō was an Akita who would meet with his owner every day at the train station. Even after his owner passed away, Hachikō continued to wait for his owner at the train station for more than 9 years. Hachikō continues to have a legacy in Japanese culture, with various statues and there was even an [American film](https://en.wikipedia.org/wiki/Hachi:_A_Dog%27s_Tale) based on him.
+We were also very inspired by the story of [Hachikō](https://en.wikipedia.org/wiki/Hachik%C5%8D) - a dog of immense loyalty. Hachikō was an Akita who would meet with his owner every day at the train station. Even after his owner passed away, Hachikō continued to wait for his owner at the train station for more than 9 years. Hachikō continues to have a legacy in Japanese culture, with various statues created in his memory - there was even an [American film](https://en.wikipedia.org/wiki/Hachi:_A_Dog%27s_Tale) based on him.

--- a/examples/example_data.json
+++ b/examples/example_data.json
@@ -12,12 +12,84 @@
 		"totalVisits": 500,
 		"totalMonetizedVisits": 30,
 		"topOriginsList": [
-			"https://sdog.netlify.app"
-			"https://dev.to",
-			"https://www.twitch.tv"
+			{
+				"origin":"https://sdog.netlify.app",
+				"isCurrentlyMonetized":true,
+				"originVisitData":{
+					"timeSpentAtOrigin": 4567890218492,
+					"numberOfVisits": 300,
+					"dateOfFirstVisit": "2020-01-01",
+					"dateOfMostRecentVisit": "2020-06-02"
+				},
+				"paymentPointerMap":{
+					"$ilp.uphold.com/DWhyhLRG7E4Q":{
+						"paymentPointer":"$ilp.uphold.com/DWhyhLRG7E4Q",
+						"sentAssetsMap":{
+							"XRP":{
+								"amount":13502,
+								"assetScale":9,
+								"assetCode":"XRP"
+							}
+						}
+					}
+				}
+			},
+			{
+				"origin":"https://dev.to",
+				"isCurrentlyMonetized":true,
+				"originVisitData":{
+					"timeSpentAtOrigin": 8731882,
+					"numberOfVisits": 3,
+					"dateOfFirstVisit": "2020-05-01",
+					"dateOfMostRecentVisit": "2020-06-02"
+				},
+				"paymentPointerMap":{
+					"$ilp.uphold.com/24HhrUGG7ekn":{
+						"paymentPointer":"$ilp.uphold.com/24HhrUGG7ekn",
+						"sentAssetsMap":{
+							"XRP":{
+								"amount":16505,
+								"assetScale":9,
+								"assetCode":"XRP"
+							}
+						}
+					}
+				}
+			}
 		],
 		"needsSomeLoveList": [
-			"https://dev.to"
+			{
+				"origin":"https://www.twitch.tv",
+				"isCurrentlyMonetized":true,
+				"originVisitData":{
+					"timeSpentAtOrigin": 4723893,
+					"numberOfVisits": 2,
+					"dateOfFirstVisit": "2020-05-15",
+					"dateOfMostRecentVisit": "2020-05-27"
+				},
+				"paymentPointerMap":{
+					"$spsp.coil.com/twitch/nasa":{
+						"paymentPointer":"$spsp.coil.com/twitch/nasa",
+						"sentAssetsMap":{
+							"XRP":{
+								"amount":5351,
+								"assetScale":9,
+								"assetCode":"XRP"
+							}
+						}
+					},
+					"$spsp.coil.com/twitch/xqcow":{
+						"paymentPointer":"$spsp.coil.com/twitch/xqcow",
+						"sentAssetsMap":{
+							"XRP":{
+								"amount":11442,
+								"assetScale":9,
+								"assetCode":"XRP"
+							}
+						}
+					}
+				}
+			}
 		],
 		"totalSentAssetsMap": {
 			"XRP": {

--- a/examples/example_data.json
+++ b/examples/example_data.json
@@ -40,7 +40,7 @@
 	"originDataList":[
 		{
 			"origin":"https://dev.to",
-			"isMonetized":true,
+			"isCurrentlyMonetized":true,
 			"originVisitData":{
 				"timeSpentAtOrigin": 8731882,
 				"numberOfVisits": 3,
@@ -62,7 +62,7 @@
 		},
 		{
 			"origin":"https://www.twitch.tv",
-			"isMonetized":true,
+			"isCurrentlyMonetized":true,
 			"originVisitData":{
 				"timeSpentAtOrigin": 4723893,
 				"numberOfVisits": 2,
@@ -94,7 +94,7 @@
 		},
 		{
 			"origin":"https://sdog.netlify.app",
-			"isMonetized":true,
+			"isCurrentlyMonetized":true,
 			"originVisitData":{
 				"timeSpentAtOrigin": 4567890218492,
 				"numberOfVisits": 300,

--- a/examples/example_data.json
+++ b/examples/example_data.json
@@ -6,6 +6,37 @@
 		"https://www.twitch.tv",
 		"https://sdog.netlify.app"
 	],
+	"originStats": {
+		"totalTimeSpent": 1834971294872194719204821,
+		"totalMonetizedTimeSpent": 194719204821,
+		"totalVisits": 500,
+		"totalMonetizedVisits": 30,
+		"topOriginsList": [
+			"https://sdog.netlify.app"
+			"https://dev.to",
+			"https://www.twitch.tv"
+		],
+		"needsSomeLoveList": [
+			"https://dev.to"
+		],
+		"totalSentAssetsMap": {
+			"XRP": {
+				"amount": 74289471,
+				"assetScale":9,
+				"assetCode":"XRP"
+			},
+			"USD": {
+				"amount": 26862,
+				"assetScale":9,
+				"assetCode":"XRP"
+			},
+			"CAD": {
+				"amount": 324824,
+				"assetScale":9,
+				"assetCode":"XRP"
+			}
+		}
+	},
 	"originDataList":[
 		{
 			"origin":"https://dev.to",

--- a/examples/example_data.json
+++ b/examples/example_data.json
@@ -1,7 +1,7 @@
 "Example of the Akita Format of storing data. Each element of the originDataList is a serialized AkitaOriginData object."
 
 {
-	"originList":[
+	"originList": [
 		"https://dev.to",
 		"https://www.twitch.tv",
 		"https://sdog.netlify.app"
@@ -11,86 +11,6 @@
 		"totalMonetizedTimeSpent": 194719204821,
 		"totalVisits": 500,
 		"totalMonetizedVisits": 30,
-		"topOriginsList": [
-			{
-				"origin":"https://sdog.netlify.app",
-				"isCurrentlyMonetized":true,
-				"originVisitData":{
-					"timeSpentAtOrigin": 4567890218492,
-					"numberOfVisits": 300,
-					"dateOfFirstVisit": "2020-01-01",
-					"dateOfMostRecentVisit": "2020-06-02"
-				},
-				"paymentPointerMap":{
-					"$ilp.uphold.com/DWhyhLRG7E4Q":{
-						"paymentPointer":"$ilp.uphold.com/DWhyhLRG7E4Q",
-						"sentAssetsMap":{
-							"XRP":{
-								"amount":13502,
-								"assetScale":9,
-								"assetCode":"XRP"
-							}
-						}
-					}
-				}
-			},
-			{
-				"origin":"https://dev.to",
-				"isCurrentlyMonetized":true,
-				"originVisitData":{
-					"timeSpentAtOrigin": 8731882,
-					"numberOfVisits": 3,
-					"dateOfFirstVisit": "2020-05-01",
-					"dateOfMostRecentVisit": "2020-06-02"
-				},
-				"paymentPointerMap":{
-					"$ilp.uphold.com/24HhrUGG7ekn":{
-						"paymentPointer":"$ilp.uphold.com/24HhrUGG7ekn",
-						"sentAssetsMap":{
-							"XRP":{
-								"amount":16505,
-								"assetScale":9,
-								"assetCode":"XRP"
-							}
-						}
-					}
-				}
-			}
-		],
-		"needsSomeLoveList": [
-			{
-				"origin":"https://www.twitch.tv",
-				"isCurrentlyMonetized":true,
-				"originVisitData":{
-					"timeSpentAtOrigin": 4723893,
-					"numberOfVisits": 2,
-					"dateOfFirstVisit": "2020-05-15",
-					"dateOfMostRecentVisit": "2020-05-27"
-				},
-				"paymentPointerMap":{
-					"$spsp.coil.com/twitch/nasa":{
-						"paymentPointer":"$spsp.coil.com/twitch/nasa",
-						"sentAssetsMap":{
-							"XRP":{
-								"amount":5351,
-								"assetScale":9,
-								"assetCode":"XRP"
-							}
-						}
-					},
-					"$spsp.coil.com/twitch/xqcow":{
-						"paymentPointer":"$spsp.coil.com/twitch/xqcow",
-						"sentAssetsMap":{
-							"XRP":{
-								"amount":11442,
-								"assetScale":9,
-								"assetCode":"XRP"
-							}
-						}
-					}
-				}
-			}
-		],
 		"totalSentAssetsMap": {
 			"XRP": {
 				"amount": 74289471,
@@ -109,7 +29,7 @@
 			}
 		}
 	},
-	"originDataList":[
+	"originDataList": [
 		{
 			"origin":"https://dev.to",
 			"isCurrentlyMonetized":true,

--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
 				"src/data/AkitaPaymentPointerData.js",
 				"src/data/AkitaOriginVisitData.js",
 				"src/data/AkitaOriginData.js",
+				"src/data/AkitaOriginStats.js",
 				"src/data/storage.js",
 				"src/content_main.js"
 			]

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,8 @@
 				"src/data/AkitaOriginData.js",
 				"src/data/AkitaOriginStats.js",
 				"src/data/storage.js",
-				"src/content_main.js"
+				"src/content_main.js",
+				"src/main.js"
 			]
 		}
 	],

--- a/src/background_script.js
+++ b/src/background_script.js
@@ -6,7 +6,7 @@ const UNMONETIZED_ICON_PATH = '../assets/icon_unmonetized.png';
 // Listen to messages sent from Content Scripts via webBrowser.runtime.sendMessage
 webBrowser.runtime.onMessage.addListener(
     (request, sender, sendResponse) => {
-        if (request.isMonetized) {
+        if (request.isCurrentlyMonetized) {
             webBrowser.browserAction.setBadgeBackgroundColor({ color: '#EF5E92' });
             webBrowser.browserAction.setBadgeText({ text: '$' });
             webBrowser.browserAction.setIcon({

--- a/src/content_main.js
+++ b/src/content_main.js
@@ -1,4 +1,3 @@
-
 /**
  * Content scripts can only see a "clean version" of the DOM, i.e. a version of the DOM without
  * properties which are added by JavaScript, such as document.monetization!
@@ -38,11 +37,20 @@ async function main() {
 		isValid,
 		paymentPointer
 	} = await getAndValidatePaymentPointer();
+
 	//TODO: call setExtensionIconMonetizationState whenever the page regains visibility so that the icon changes between tabs:
 	setExtensionIconMonetizationState(isValid);
 
 	// paymentPointer will be null if it doesn't exist or is invalid
 	await storeDataIntoAkitaFormat({ paymentPointer: paymentPointer }, AKITA_DATA_TYPE.PAYMENT);
+
+	// Test storing assets
+	// await storeDataIntoAkitaFormat({
+	// 	paymentPointer: paymentPointer,
+	// 	assetCode: "USD",
+	// 	assetScale: 9,
+	// 	amount: 123456
+	// }, AKITA_DATA_TYPE.PAYMENT);
 
 	document.addEventListener('akita_monetizationprogress', (event) => {
 		storeDataIntoAkitaFormat(event.detail, AKITA_DATA_TYPE.PAYMENT);

--- a/src/content_main.js
+++ b/src/content_main.js
@@ -29,7 +29,6 @@ main();
  * Main function to initiate the application.
  */
 async function main() {
-	await trackVisitToSite();
 	await trackTimeOnSite();
 
 	// TODO: check payment pointer periodically for existence and validity
@@ -47,6 +46,8 @@ async function main() {
 	document.addEventListener('akita_monetizationprogress', (event) => {
 		storeDataIntoAkitaFormat(event.detail, AKITA_DATA_TYPE.PAYMENT);
 	});
+
+	await trackVisitToSite();
 
 	// For TESTING purposes: output all stored data to the console (not including current site)
 	loadAllData().then(result => console.log(JSON.stringify(result, null, 2)));
@@ -140,10 +141,14 @@ function getCurrentTime() {
 /**
  * Store the recent time spent in the webpage session into AkitaFormat.
  * 
- * @param {Number} recentTimeSpent The recent time spent on the webpage.
+ * @param {Number} recentTimeSpent The recent time spent on the webpage. This number is
+ * a Double, since performance.now() is used to construct this number.
  */
 async function storeRecentTimeSpent(recentTimeSpent) {
-	await storeDataIntoAkitaFormat(recentTimeSpent, AKITA_DATA_TYPE.ORIGIN_TIME_SPENT);
+	// Round the number up so that it is a whole number.
+	const recentTimeSpentRounded = Math.ceil(recentTimeSpent);
+
+	await storeDataIntoAkitaFormat(recentTimeSpentRounded, AKITA_DATA_TYPE.ORIGIN_TIME_SPENT);
 }
 
 /***********************************************************

--- a/src/data/AkitaOriginData.js
+++ b/src/data/AkitaOriginData.js
@@ -10,7 +10,7 @@
  */
 class AkitaOriginData {
 	origin = null;
-	isMonetized = false;
+	isCurrentlyMonetized = false;
 	// The type of each entry in paymentPointerMap is: AkitaPaymentPointerData
 	paymentPointerMap = {};
 
@@ -32,7 +32,7 @@ class AkitaOriginData {
 	 */
 	static fromObject(akitaOriginDataObject) {
 		const newOriginData = new AkitaOriginData(akitaOriginDataObject.origin);
-		newOriginData.isMonetized = akitaOriginDataObject.isMonetized;
+		newOriginData.isCurrentlyMonetized = akitaOriginDataObject.isCurrentlyMonetized;
 
 		for (const paymentPointer in akitaOriginDataObject.paymentPointerMap) {
 			newOriginData.paymentPointerMap[paymentPointer] = AkitaPaymentPointerData.fromObject(
@@ -69,20 +69,28 @@ class AkitaOriginData {
 	 *
 	 *	 reference: https://webmonetization.org/docs/api#example-event-object-3
 	 */
-	updatePaymentData({
-		paymentPointer,
-		assetCode = null,
-		assetScale = null,
-		amount = null
-	}) {
-		if (paymentPointer) {
-			this.isMonetized = true;
-			if (!this.paymentPointerMap[paymentPointer]) {
-				this.paymentPointerMap[paymentPointer] = new AkitaPaymentPointerData(paymentPointer);
+	updatePaymentData(paymentData) {
+		if (paymentData) {
+			const paymentPointer = paymentData.paymentPointer;
+			
+			if (paymentPointer) {
+				this.isCurrentlyMonetized = true;
+
+				if (!this.paymentPointerMap[paymentPointer]) {
+					this.paymentPointerMap[paymentPointer] = new AkitaPaymentPointerData(paymentPointer);
+				}
+
+				const assetCode = paymentData.assetCode;
+				const assetScale = paymentData.assetScale;
+				const amount = paymentData.amount;
+
+				if (assetCode !== null && amount !== null && assetScale !== null) {
+					this.paymentPointerMap[paymentPointer].addAsset(assetCode, Number(amount), Number(assetScale));
+				}
 			}
-			if (assetCode !== null && amount !== null && assetScale !== null) {
-				this.paymentPointerMap[paymentPointer].addAsset(assetCode, Number(amount), Number(assetScale));
-			}
+		} else {
+			// If paymentData is null then monetization is pending or was stopped
+			this.isCurrentlyMonetized = false;
 		}
 	}
 

--- a/src/data/AkitaOriginData.js
+++ b/src/data/AkitaOriginData.js
@@ -96,7 +96,7 @@ class AkitaOriginData {
 	/**
 	 * Update time spent at the origin.
 	 * 
-	 * @param {Number} recentTimeSpent The time spent at the origin in a session.
+	 * @param {Number} recentTimeSpent The recent time spent at the origin.
 	 */
 	addTimeSpent(recentTimeSpent = 0) {
 		this.originVisitData.addTimeSpent(recentTimeSpent);

--- a/src/data/AkitaOriginData.js
+++ b/src/data/AkitaOriginData.js
@@ -42,7 +42,7 @@ class AkitaOriginData {
 
 		// Add deserialization for originVisitData
 		const originVisitDataDeserialized = AkitaOriginVisitData.fromObject(akitaOriginDataObject.originVisitData);
-		if (originVisitDataDeserialized !== null) {
+		if (originVisitDataDeserialized) {
 			newOriginData.originVisitData = originVisitDataDeserialized;
 		}
 
@@ -52,9 +52,9 @@ class AkitaOriginData {
 	/**
 	 * @param {{
 	 *	paymentPointer: String,
-	 *	assetCode?: String,
+	 *	amount?: Number,
 	 *	assetScale?: Number,
-	 *	amount?: Number
+	 *	assetCode?: String
 	 * }} paymentData
 	 *	 This object may be created, or a Web Monetization event detail object can be used.
 	 *	 Pass in an object with just a paymentPointer to register a payment pointer for
@@ -80,12 +80,12 @@ class AkitaOriginData {
 					this.paymentPointerMap[paymentPointer] = new AkitaPaymentPointerData(paymentPointer);
 				}
 
-				const assetCode = paymentData.assetCode;
-				const assetScale = paymentData.assetScale;
 				const amount = paymentData.amount;
+				const assetScale = paymentData.assetScale;
+				const assetCode = paymentData.assetCode;
 
-				if (assetCode !== null && amount !== null && assetScale !== null) {
-					this.paymentPointerMap[paymentPointer].addAsset(assetCode, Number(amount), Number(assetScale));
+				if (!isNaN(amount) && !isNaN(assetScale) && assetCode) {
+					this.paymentPointerMap[paymentPointer].addAsset(amount, assetScale, assetCode);
 				}
 			}
 		} else {

--- a/src/data/AkitaOriginStats.js
+++ b/src/data/AkitaOriginStats.js
@@ -1,0 +1,140 @@
+/**
+ * Holds calculated origin stats based on data stored in Akita.
+ * 
+ * Refer to originStats in example_data.json for an example.
+ * 
+ * Origin stats include:
+ *   - total time spent at all origins since using Akita (in milliseconds)
+ *   - total time spent at all monetized origins since using Akita (in milliseconds)
+ *   - total number of visits to all origins recorded in Akita
+ *   - total number of visits to monetized origins recorded in Akita
+ *   - list of top 5 origins by visit time (ordered by amount of time spent)
+ *   - list of top 5 origins by "needing some love" ()
+ *   - map of totalSentAssets, with an entry for each currency
+ */
+
+class AkitaOriginStats {
+	totalTimeSpent = 0;
+	totalMonetizedTimeSpent = 0;
+	totalVisits = 0;
+	totalMonetizedVisits = 0;
+
+	// Each entry is an origin (String)
+	topOriginsList = [];
+
+	// Each entry is an origin (String)
+	needsSomeLoveList = [];
+
+	// The type of each entry in sentAssetsMap is: WebMonetizationAsset
+	totalSentAssetsMap = {};
+
+	/**
+	 * This function takes an object with the same properties as AkitaOriginStats,
+	 * i.e. an AkitaOriginStats instance which has been stored and loaded from browser storage,
+	 * and copies the object's properties over to an AkitaOriginStats instance.
+	 *
+	 * @param {Object} akitaOriginStats an object with the same properties as an AkitaOriginStats object.
+	 * @return {AkitaOriginStats} the input object as an instance of the AkitaOriginStats class.
+	 */
+	static fromObject(akitaOriginStats) {
+		const newAkitaOriginStats = new AkitaOriginStats();
+
+		newAkitaOriginStats.totalTimeSpent = akitaOriginStats.totalTimeSpent;
+		newAkitaOriginStats.totalMonetizedTimeSpent = akitaOriginStats.totalMonetizedTimeSpent;
+		newAkitaOriginStats.totalVisits = akitaOriginStats.totalVisits;
+		newAkitaOriginStats.totalMonetizedVisits = akitaOriginStats.totalMonetizedVisits;
+		newAkitaOriginStats.topOriginsList = akitaOriginStats.topOriginsList;
+		newAkitaOriginStats.needsSomeLoveList = akitaOriginStats.needsSomeLoveList;
+		
+		for (const assetCode in akitaOriginStats.totalSentAssetsMap) {
+			newAkitaOriginStats.totalSentAssetsMap[assetCode] = WebMonetizationAsset.fromObject(
+				totalSentAssetsMap[assetCode]
+			);
+		}
+
+		return newAkitaOriginStats;
+	}
+
+	/***********************************************************
+	 * Update Time Spent
+	 ***********************************************************/
+
+	/**
+	 * Update the total monetized time spent if the origin is monetized, and update
+	 * the total time spent regardless.
+	 * 
+	 * @param {Number} recentTimeSpent The new amount of time spent at the origin.
+	 * @param {Boolean} originIsMonetized Whether the origin is monetized or not.
+	 */
+	updateTimeSpent(recentTimeSpent, originIsMonetized) {
+		if (originIsMonetized) {
+			this.updateTotalMonetizedTimeSpent(recentTimeSpent);
+		}
+		this.updateTotalTimeSpent(recentTimeSpent);	
+	}
+
+	/**
+	 * Update the total time spent at all origins.
+	 * 
+	 * @param {Number} recentTimeSpent The new amount of time spent at the origin.
+	 */
+	updateTotalTimeSpent(recentTimeSpent) {
+		this.totalTimeSpent += recentTimeSpent;
+	}
+
+	/**
+	 * Update the total time spent at monetized origins.
+	 * 
+	 * @param {Number} recentTimeSpent The new amount of time spent at the origin.
+	 */
+	updateTotalMonetizedTimeSpent(recentTimeSpent) {
+		this.totalMonetizedTimeSpent += recentTimeSpent;
+	}
+
+	/***********************************************************
+	 * Update Visits
+	 ***********************************************************/
+
+	/**
+	 * Update the total visits to monetized origins if the origin is monetized,
+	 * and update the total visits to origins regardless.
+	 * 
+	 * @param {Boolean} originIsMonetized Whether the origin is monetized or not.
+	 */
+	incrementVisits(originIsMonetized) {
+		if (originIsMonetized) {
+			this.incrementTotalMonetizedVisits();
+		}
+		this.incrementTotalVisits();
+	}
+
+	/**
+	 * Increment the total visits to origins.
+	 */
+	incrementTotalVisits() {
+		this.totalVisits += 1;
+	}
+
+	/**
+	 * Increment the total visits to monetized origins.
+	 */
+	incrementTotalMonetizedVisits() {
+		this.totalMonetizedVisits += 1;
+	}
+
+	/***********************************************************
+	 * Update Lists/Map
+	 ***********************************************************/
+
+	setTopOriginsList(newTopOriginsList) {
+		this.topOriginsList = newTopOriginsList;
+	}
+
+	setNeedsSomeLoveList(newNeedsSomeLoveList) {
+		this.needsSomeLoveList = newNeedsSomeLoveList;
+	}
+
+	setTotalSentAssetsMap(newTotalSentAssetsMap) {
+		this.totalSentAssetsMap = newTotalSentAssetsMap;
+	}
+}

--- a/src/data/AkitaOriginStats.js
+++ b/src/data/AkitaOriginStats.js
@@ -12,7 +12,6 @@
  *   - list of top 5 origins by "needing some love" ()
  *   - map of totalSentAssets, with an entry for each currency
  */
-
 class AkitaOriginStats {
 	totalTimeSpent = 0;
 	totalMonetizedTimeSpent = 0;
@@ -144,9 +143,9 @@ class AkitaOriginStats {
 	 * 
 	 * @param {{
 	 *	paymentPointer: String,
-	 *	assetCode?: String,
+	 *	amount?: Number,
 	 *	assetScale?: Number,
-	 *	amount?: Number
+	 *	assetCode?: String
 	 * }} paymentData
 	 *	 This object may be created, or a Web Monetization event detail object can be used.
 	 *	 Pass in an object with just a paymentPointer to register a payment pointer for
@@ -163,15 +162,14 @@ class AkitaOriginStats {
 	 */
 	updateAssetsMapWithAsset({
 		paymentPointer,
-		assetCode = null,
+		amount = null,
 		assetScale = null,
-		amount = null
+		assetCode = null
 	}) {
-		if (assetCode !== null && amount !== null && assetScale !== null) {
+		if (!isNaN(amount) && !isNaN(assetScale) && assetCode) {
 			if (!this.totalSentAssetsMap[assetCode]) {
 				this.totalSentAssetsMap[assetCode] = new WebMonetizationAsset(assetCode);
 			}
-
 			this.totalSentAssetsMap[assetCode].addAmount(amount, assetScale);
 		}
 	}

--- a/src/data/AkitaOriginStats.js
+++ b/src/data/AkitaOriginStats.js
@@ -48,7 +48,7 @@ class AkitaOriginStats {
 		
 		for (const assetCode in akitaOriginStats.totalSentAssetsMap) {
 			newAkitaOriginStats.totalSentAssetsMap[assetCode] = WebMonetizationAsset.fromObject(
-				totalSentAssetsMap[assetCode]
+				akitaOriginStats.totalSentAssetsMap[assetCode]
 			);
 		}
 
@@ -64,10 +64,10 @@ class AkitaOriginStats {
 	 * the total time spent regardless.
 	 * 
 	 * @param {Number} recentTimeSpent The new amount of time spent at the origin.
-	 * @param {Boolean} originIsMonetized Whether the origin is monetized or not.
+	 * @param {Boolean} originisCurrentlyMonetized Whether the origin is monetized or not.
 	 */
-	updateTimeSpent(recentTimeSpent, originIsMonetized) {
-		if (originIsMonetized) {
+	updateTimeSpent(recentTimeSpent, originisCurrentlyMonetized) {
+		if (originisCurrentlyMonetized) {
 			this.updateTotalMonetizedTimeSpent(recentTimeSpent);
 		}
 		this.updateTotalTimeSpent(recentTimeSpent);	
@@ -99,10 +99,10 @@ class AkitaOriginStats {
 	 * Update the total visits to monetized origins if the origin is monetized,
 	 * and update the total visits to origins regardless.
 	 * 
-	 * @param {Boolean} originIsMonetized Whether the origin is monetized or not.
+	 * @param {Boolean} originisCurrentlyMonetized Whether the origin is monetized or not.
 	 */
-	incrementVisits(originIsMonetized) {
-		if (originIsMonetized) {
+	incrementVisits(originisCurrentlyMonetized) {
+		if (originisCurrentlyMonetized) {
 			this.incrementTotalMonetizedVisits();
 		}
 		this.incrementTotalVisits();
@@ -134,7 +134,45 @@ class AkitaOriginStats {
 		this.needsSomeLoveList = newNeedsSomeLoveList;
 	}
 
-	setTotalSentAssetsMap(newTotalSentAssetsMap) {
-		this.totalSentAssetsMap = newTotalSentAssetsMap;
+	/***********************************************************
+	 * Update Total Sent Assets Map
+	 ***********************************************************/
+
+	/**
+	 * Update the total sent assets map by adding the amount to an existing
+	 * asset (currency) or create a new asset in the total sent assets map.
+	 * 
+	 * @param {{
+	 *	paymentPointer: String,
+	 *	assetCode?: String,
+	 *	assetScale?: Number,
+	 *	amount?: Number
+	 * }} paymentData
+	 *	 This object may be created, or a Web Monetization event detail object can be used.
+	 *	 Pass in an object with just a paymentPointer to register a payment pointer for
+	 *	 the current website. Payment pointer should be validated first.
+	 *	 Additionally pass in assetCode, assetScale, and amount together to add to the
+	 *	 total amount sent to the current website.
+	 *
+	 *	 assetCode e.g. 'XRP', 'USD', 'CAD'
+	 *	 assetScale and amount e.g.
+	 *		 if assetCode is 'USD', amount is 235, assetScale is 3 then actual amount of
+	 *		 currency is 235 * 10**(-3) = $0.235 USD or twenty-three and one-half cents.
+	 *
+	 *	 reference: https://webmonetization.org/docs/api#example-event-object-3
+	 */
+	updateAssetsMapWithAsset({
+		paymentPointer,
+		assetCode = null,
+		assetScale = null,
+		amount = null
+	}) {
+		if (assetCode !== null && amount !== null && assetScale !== null) {
+			if (!this.totalSentAssetsMap[assetCode]) {
+				this.totalSentAssetsMap[assetCode] = new WebMonetizationAsset(assetCode);
+			}
+
+			this.totalSentAssetsMap[assetCode].addAmount(amount, assetScale);
+		}
 	}
 }

--- a/src/data/AkitaOriginStats.js
+++ b/src/data/AkitaOriginStats.js
@@ -8,8 +8,6 @@
  *   - total time spent at all monetized origins since using Akita (in milliseconds)
  *   - total number of visits to all origins recorded in Akita
  *   - total number of visits to monetized origins recorded in Akita
- *   - list of top 5 origins by visit time (ordered by amount of time spent)
- *   - list of top 5 origins by "needing some love" ()
  *   - map of totalSentAssets, with an entry for each currency
  */
 class AkitaOriginStats {
@@ -18,13 +16,7 @@ class AkitaOriginStats {
 	totalVisits = 0;
 	totalMonetizedVisits = 0;
 
-	// Each entry is an origin (String)
-	topOriginsList = [];
-
-	// Each entry is an origin (String)
-	needsSomeLoveList = [];
-
-	// The type of each entry in sentAssetsMap is: WebMonetizationAsset
+	// The type of each entry in totalSentAssetsMap is: WebMonetizationAsset
 	totalSentAssetsMap = {};
 
 	/**
@@ -42,9 +34,7 @@ class AkitaOriginStats {
 		newAkitaOriginStats.totalMonetizedTimeSpent = akitaOriginStats.totalMonetizedTimeSpent;
 		newAkitaOriginStats.totalVisits = akitaOriginStats.totalVisits;
 		newAkitaOriginStats.totalMonetizedVisits = akitaOriginStats.totalMonetizedVisits;
-		newAkitaOriginStats.topOriginsList = akitaOriginStats.topOriginsList;
-		newAkitaOriginStats.needsSomeLoveList = akitaOriginStats.needsSomeLoveList;
-		
+
 		for (const assetCode in akitaOriginStats.totalSentAssetsMap) {
 			newAkitaOriginStats.totalSentAssetsMap[assetCode] = WebMonetizationAsset.fromObject(
 				akitaOriginStats.totalSentAssetsMap[assetCode]
@@ -59,17 +49,18 @@ class AkitaOriginStats {
 	 ***********************************************************/
 
 	/**
-	 * Update the total monetized time spent if the origin is monetized, and update
+	 * Update the total monetized time spent if the origin is monetized; update
 	 * the total time spent regardless.
 	 * 
 	 * @param {Number} recentTimeSpent The new amount of time spent at the origin.
-	 * @param {Boolean} originisCurrentlyMonetized Whether the origin is monetized or not.
+	 * @param {Boolean} originIsCurrentlyMonetized Whether the origin is monetized or not.
 	 */
-	updateTimeSpent(recentTimeSpent, originisCurrentlyMonetized) {
-		if (originisCurrentlyMonetized) {
+	updateTimeSpent(recentTimeSpent, originIsCurrentlyMonetized) {
+		this.updateTotalTimeSpent(recentTimeSpent);
+
+		if (originIsCurrentlyMonetized) {
 			this.updateTotalMonetizedTimeSpent(recentTimeSpent);
 		}
-		this.updateTotalTimeSpent(recentTimeSpent);	
 	}
 
 	/**
@@ -98,10 +89,10 @@ class AkitaOriginStats {
 	 * Update the total visits to monetized origins if the origin is monetized,
 	 * and update the total visits to origins regardless.
 	 * 
-	 * @param {Boolean} originisCurrentlyMonetized Whether the origin is monetized or not.
+	 * @param {Boolean} originIsCurrentlyMonetized Whether the origin is monetized or not.
 	 */
-	incrementVisits(originisCurrentlyMonetized) {
-		if (originisCurrentlyMonetized) {
+	incrementVisits(originIsCurrentlyMonetized) {
+		if (originIsCurrentlyMonetized) {
 			this.incrementTotalMonetizedVisits();
 		}
 		this.incrementTotalVisits();
@@ -119,18 +110,6 @@ class AkitaOriginStats {
 	 */
 	incrementTotalMonetizedVisits() {
 		this.totalMonetizedVisits += 1;
-	}
-
-	/***********************************************************
-	 * Update Lists/Map
-	 ***********************************************************/
-
-	setTopOriginsList(newTopOriginsList) {
-		this.topOriginsList = newTopOriginsList;
-	}
-
-	setNeedsSomeLoveList(newNeedsSomeLoveList) {
-		this.needsSomeLoveList = newNeedsSomeLoveList;
 	}
 
 	/***********************************************************

--- a/src/data/AkitaOriginVisitData.js
+++ b/src/data/AkitaOriginVisitData.js
@@ -26,7 +26,7 @@ class AkitaOriginVisitData {
 	static fromObject(akitaOriginVisitDataObject) {
 		let newOriginVisitData = null;
 
-		if (akitaOriginVisitDataObject !== null) {
+		if (akitaOriginVisitDataObject) {
 			newOriginVisitData = new AkitaOriginVisitData();
 			newOriginVisitData.timeSpentAtOrigin = akitaOriginVisitDataObject.timeSpentAtOrigin;
 			newOriginVisitData.numberOfVisits = akitaOriginVisitDataObject.numberOfVisits;

--- a/src/data/AkitaOriginVisitData.js
+++ b/src/data/AkitaOriginVisitData.js
@@ -41,11 +41,9 @@ class AkitaOriginVisitData {
 	 * Update the total time spent by adding the recent time to the total.
 	 * 
 	 * @param {Number} recentTimeSpentAtOrigin The new amount of time spent at the origin.
-	 *   This number is a Double, since performance.now() is used to construct this number.
 	 */
 	addTimeSpent(recentTimeSpentAtOrigin = 0) {
-		// Since recentTimeSpentAtOrigin is a double, we take the floor of the value.
-		this.timeSpentAtOrigin += Math.floor(recentTimeSpentAtOrigin);
+		this.timeSpentAtOrigin += recentTimeSpentAtOrigin;
 	}
 
 	/**

--- a/src/data/AkitaPaymentPointerData.js
+++ b/src/data/AkitaPaymentPointerData.js
@@ -35,15 +35,18 @@ class AkitaPaymentPointerData {
 	 *		if assetCode is 'USD', amount is 235, and assetScale is 3 then actual amount of
 	 *		currency is 235 * 10**(-3) = $0.235 USD or twenty-three and one-half cents.
 	 *
-	 * @param {String} assetCode the currency of the asset, such as 'USD', 'CAD', or 'XRP'.
 	 * @param {Number} amount the total amount of the currency, before scaling by assetScale.
 	 * @param {Number} assetScale multiply amount by 10 to the power of negative assetScale to
 	 * convert to actual currency value.
+	 * @param {String} assetCode the currency of the asset, such as 'USD', 'CAD', or 'XRP'.
+	 * 
 	 */
-	addAsset(assetCode, amount, assetScale) {
-		if (!this.sentAssetsMap[assetCode]) {
-			this.sentAssetsMap[assetCode] = new WebMonetizationAsset(assetCode);
+	addAsset(amount, assetScale, assetCode) {
+		if (assetCode && !isNaN(amount) && !isNaN(assetScale)) {
+			if (!this.sentAssetsMap[assetCode]) {
+				this.sentAssetsMap[assetCode] = new WebMonetizationAsset(assetCode);
+			}
+			this.sentAssetsMap[assetCode].addAmount(amount, assetScale);
 		}
-		this.sentAssetsMap[assetCode].addAmount(amount, assetScale);
 	}
 }

--- a/src/data/WebMonetizationAsset.js
+++ b/src/data/WebMonetizationAsset.js
@@ -15,9 +15,7 @@ class WebMonetizationAsset {
 	assetScale = 0;
 	assetCode = null;
 
-	constructor(amount, assetScale, assetCode) {
-		this.amount = amount;
-		this.assetScale = assetScale;
+	constructor(assetCode) {
 		this.assetCode = assetCode;
 	}
 
@@ -30,12 +28,10 @@ class WebMonetizationAsset {
 	 * @return {WebMonetizationAsset} the input object as an instance of the WebMonetizationAsset class.
 	 */
 	static fromObject(webMonetizationAsset) {
-		const newWebMonetizationAsset =
-			new WebMonetizationAsset(
-				webMonetizationAsset.amount,
-				webMonetizationAsset.assetScale,
-				webMonetizationAsset.assetCode
-			);
+		const newWebMonetizationAsset = new WebMonetizationAsset(webMonetizationAsset.assetCode);
+
+		newWebMonetizationAsset.amount = webMonetizationAsset.amount;
+		newWebMonetizationAsset.assetScale = webMonetizationAsset.assetScale;
 
 		return newWebMonetizationAsset;
 	}
@@ -49,11 +45,15 @@ class WebMonetizationAsset {
 	 * @param {Number} assetScale multiply amount by 10 to the power of negative assetScale to
 	 * convert to actual currency value.
 	 */
-	addAmount(amount, assetScale) {
+	addAmount(newAmount, newAssetScale) {
+		const amount = Number(newAmount);
+		const assetScale = Number(newAssetScale);
+
 		// Always convert to a smaller asset scale to avoid a fractional amount.
 		if (this.assetScale < assetScale) {
 			this.convertAmountToNewAssetScale(assetScale);
 		}
+
 		this.amount += amount;
 	}
 

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -123,6 +123,8 @@ function updateTimeSpent(originData, originStats, recentTimeSpent = 0) {
  ***********************************************************/
 
 /**
+ * Load origin stats from storage.
+ * 
  * @return {Promise<string[]>} asynchronously load from storage. Resolves to the origin stats.
  **/
 async function loadOriginStats() {
@@ -142,6 +144,8 @@ async function loadOriginStats() {
 }
 
 /**
+ * Store origin stats to storage.
+ * 
  * @param {AkitaOriginStats]} originStats an AkitaOriginStats object.
  * @return {Promise<AkitaOriginStats>} asynchronously store (overwrite) data in storage. Resolves to the AkitaOriginStats object which was stored.
  **/

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -79,9 +79,9 @@ async function storeDataIntoAkitaFormat(data, typeOfData) {
  * @param {AkitaOriginStats} originStats The origin stats to update.
  * @param {{
  *	paymentPointer: String,
- *	assetCode?: String,
+ *	amount?: Number,
  *	assetScale?: Number,
- *	amount?: Number
+ *	assetCode?: String
  * }} paymentData
  * 	 This object may be created, or a Web Monetization event detail object can be used.
  * 	 Pass in an object with just a paymentPointer to register a payment pointer for

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -10,6 +10,7 @@ const AKITA_DATA_TYPE = {
 
 const ORIGIN_NAME_LIST_KEY = 'originList';
 const ORIGIN_STATS_KEY = 'originStats';
+const ORIGIN_DATA_LIST_KEY = 'originDataList';
 let webBrowser = chrome ? chrome : browser;
 
 /**
@@ -163,6 +164,35 @@ async function storeOriginStats(originStats) {
  ***********************************************************/
 
 /**
+ * Get the entire list of origin data, 'originDataList' in example_data.json
+ * 
+ * @return {Promise<[AkitaOriginData]>} asynchronously load from storage.
+ *   Resolves to a list of all AkitaOriginData in storage.
+ */
+async function getOriginDataList() {
+	const originList = await getOriginList();
+
+	return new Promise((resolve, reject) => {
+		webBrowser.storage.local.get(
+			originList,
+			(storageObject) => {
+				if (storageObject) {
+					let originDataList = [];
+
+					for (const originData in storageObject) {
+						originDataList.push(AkitaOriginData.fromObject(storageObject[originData]));
+					}
+
+					resolve(originDataList);
+				} else {
+					resolve(null);
+				}
+			}
+		);
+	});
+}
+
+/**
  * @param {string} origin identify a website by origin.
  * @return {Promise<AkitaOriginData>} asynchronously load from storage. 
  *	 Resolves to the AkitaOriginData associated with the website.
@@ -225,7 +255,7 @@ async function loadAllData() {
 	return {
 		[ORIGIN_NAME_LIST_KEY]: originList,
 		[ORIGIN_STATS_KEY]: originStats,
-		originDataList: await Promise.all(promiseList)
+		[ORIGIN_DATA_LIST_KEY]: await Promise.all(promiseList)
 	};
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -112,6 +112,43 @@ async function getTopOriginsThatNeedSomeLove(nTopOrigins) {
 	return topOriginsList;
 }
 
+/***********************************************************
+ * Payment Prediction
+ ***********************************************************/
+
+/**
+ * This stream rate is based on Coil's $0.36 USD/hour rate, as
+ * described in https://help.coil.com/accounts/membership-accounts#how-much-do-you-pay-out-to-creators
+ * 
+ * 0.36/hour = 0.0000001/millisecond
+ */
+const STREAM_RATE_PER_MILLISECOND = 0.0000001;
+
+/**
+ * Calculate the estimated payment to the site in USD.
+ * 
+ * @param {String} origin The origin of the site to estimate payment for.
+ * @return {Promise<Number>} The estimated payment to the site in USD.
+ */
+async function getEstimatedPaymentForOriginUSD(origin) {
+    const originData = await loadOriginData(origin);
+    let estimatedPayment = 0;
+
+    if (originData) {
+        const timeSpentAtOrigin = originData.originVisitData.timeSpentAtOrigin;
+        estimatedPayment = Number.parseFloat(timeSpentAtOrigin * STREAM_RATE_PER_MILLISECOND).toFixed(2);
+    }
+
+    return estimatedPayment;
+}
+
+/***********************************************************
+ * Various data retrieval functions
+ ***********************************************************/
+
+// TODO: % monetized time/total time
+// TODO: % monetized visits/total visits
+
 /**
  * Get all the monetized originData objects in a list.
  * 

--- a/src/main.js
+++ b/src/main.js
@@ -131,23 +131,58 @@ const STREAM_RATE_PER_MILLISECOND = 0.0000001;
  * @return {Promise<Number>} The estimated payment to the site in USD.
  */
 async function getEstimatedPaymentForOriginUSD(origin) {
-    const originData = await loadOriginData(origin);
-    let estimatedPayment = 0;
+	const originData = await loadOriginData(origin);
+	let estimatedPayment = 0;
 
-    if (originData) {
-        const timeSpentAtOrigin = originData.originVisitData.timeSpentAtOrigin;
-        estimatedPayment = Number.parseFloat(timeSpentAtOrigin * STREAM_RATE_PER_MILLISECOND).toFixed(2);
-    }
+	if (originData) {
+		const timeSpentAtOrigin = originData.originVisitData.timeSpentAtOrigin;
+		estimatedPayment = Number.parseFloat(timeSpentAtOrigin * STREAM_RATE_PER_MILLISECOND).toFixed(2);
+	}
 
-    return estimatedPayment;
+	return estimatedPayment;
 }
 
 /***********************************************************
  * Various data retrieval functions
  ***********************************************************/
 
-// TODO: % monetized time/total time
-// TODO: % monetized visits/total visits
+/**
+ * Get the percentage of monetized origin time spent out of
+ * total origin time spent.
+ * 
+ * @param {AkitaOriginStats} originStats The origin stats object.
+ * @return {Promise<Number>} Resolves to the percent of monetized origin time spent.
+ */
+async function getMonetizedTimeSpentPercent(originStats) {
+	const totalMonetizedTimeSpent = originStats.totalMonetizedTimeSpent;
+	const totalTimeSpent = originStats.totalTimeSpent;
+
+	return toPercent(totalMonetizedTimeSpent / totalTimeSpent);
+}
+
+/**
+ * Get the percentage of monetized origin visits out of total
+ * origin visits.
+ * 
+ * @param {AkitaOriginStats} originStats The origin stats object.
+ * @return {Promise<Number>} Resolves to the percent of monetized origin visits.
+ */
+async function getMonetizedVisitsPercent(originStats) {
+	const totalMonetizedVisits = originStats.totalMonetizedVisits;
+	const totalVisits = originStats.totalVisits;
+
+	return toPercent(totalMonetizedVisits / totalVisits);
+}
+
+/**
+ * Convert a number to a percent with no decimal places.
+ * 
+ * @param {Number} number The number to convert into a percent.
+ * @return {Number} The number as a percent.
+ */
+function toPercent(number){
+	return Math.floor(100 * number);
+}
 
 /**
  * Get all the monetized originData objects in a list.
@@ -172,8 +207,8 @@ async function getMonetizedOriginDataList() {
  * @return {Promise<Number>} Resolves to the number of unique origins visited.
  */
 async function getNumberOfOriginsVisited() {
-    const originDataList = await getOriginDataList();
-    return originDataList ? originDataList.length : -1;
+	const originDataList = await getOriginDataList();
+	return originDataList ? originDataList.length : -1;
 }
 
 /**
@@ -182,6 +217,6 @@ async function getNumberOfOriginsVisited() {
  * @return {Promise<Number>} Resolves to the number of unique monetized origins visited.
  */
 async function getNumberOfMonetizedOriginsVisited() {
-    const originDataList = await getMonetizedOriginDataList();
-    return originDataList ? originDataList.length : -1;
+	const originDataList = await getMonetizedOriginDataList();
+	return originDataList ? originDataList.length : -1;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -128,3 +128,23 @@ async function getMonetizedOriginDataList() {
 
 	return monetizedOriginDataList;
 }
+
+/**
+ * Get the number of unique origins visited.
+ * 
+ * @return {Promise<Number>} Resolves to the number of unique origins visited.
+ */
+async function getNumberOfOriginsVisited() {
+    const originDataList = await getOriginDataList();
+    return originDataList ? originDataList.length : -1;
+}
+
+/**
+ * Get the number of unique monetized origins visited.
+ * 
+ * @return {Promise<Number>} Resolves to the number of unique monetized origins visited.
+ */
+async function getNumberOfMonetizedOriginsVisited() {
+    const originDataList = await getMonetizedOriginDataList();
+    return originDataList ? originDataList.length : -1;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,130 @@
+/**
+ * This file contains functions used to populate the UI with data.
+ */
+
+/***********************************************************
+ * Get Top Origins
+ ***********************************************************/
+
+/**
+ * Get the top N monetized origins based on time spent at the origin.
+ * 
+ * @param {Number} nTopOrigins The number of top monetized origins to retrieve.
+ * @return {Promise<[AkitaOriginData]>} Resolves to a list of nTopOrigins AkitaOriginData objects.
+ */
+async function getTopOriginsByTimeSpent(nTopOrigins) {
+	let monetizedOriginDataList = await getMonetizedOriginDataList();
+	let topOriginsList = null;
+	let listSize = nTopOrigins - 1;
+
+	if (monetizedOriginDataList) {
+		if (monetizedOriginDataList.length > 1) {
+			// Sort the list of origin data by timeSpentAtOrigin,
+			// i.e. sort by descending time starting from index 0
+			monetizedOriginDataList.sort((a, b) => {
+				return b.originVisitData.timeSpentAtOrigin - a.originVisitData.timeSpentAtOrigin
+			});
+
+			listSize = (listSize < monetizedOriginDataList.length) ? listSize : monetizedOriginDataList.length;
+			topOriginsList = monetizedOriginDataList.slice(0, listSize);
+		} else {
+			topOriginsList = monetizedOriginDataList;
+		}
+	}
+
+	return topOriginsList;
+}
+
+/**
+ * Constants used to calculate how much love an origin needs relative to
+ * another origin.
+ */
+const NEEDS_LOVE_MAGIC_NUMBER_MARGIN = 0.25;
+const NEEDS_LOVE_MAGIC_NUMBER = 1;
+
+/**
+ * Get the top N monetized origins based on how much the origin
+ * "needs some love" compared to other monetized origins. 
+ * 
+ * To calculate how much an origin "needs love", get the ratio of timeSpent
+ * to visits. i.e. "needs love ratio" = timeSpentAtOrigin / numberOfVisits.
+ * A small ratio indicates that, relative to how many times the user visits
+ * the monetized site, they don't seem to spend much time there. We'd like to
+ * inform the user if this is the case, so that the user can consider spending
+ * more time on that site to support the creator (more time on the site = more
+ * payment streamed if they are using a payment provider). A bit more complexity
+ * is added to determining relative "love needed" by using the NEEDS_LOVE_MAGIC_NUMBER
+ * and NEEDS_LOVE_MAGIC_NUMBER_MARGIN constants.
+ * 
+ * @param {Number} nTopOrigins The number of "top monetized origins that need some love" to retrieve.
+ * @return {Promise<[AkitaOriginData]>} Resolves to a list of nTopOrigins AkitaOriginData objects.
+ */
+async function getTopOriginsThatNeedSomeLove(nTopOrigins) {
+	let monetizedOriginDataList = await getMonetizedOriginDataList();
+	let topOriginsList = null;
+	let listSize = nTopOrigins - 1;
+
+	if (monetizedOriginDataList) {
+		if (monetizedOriginDataList.length > 1) {
+			// Sort the list of origin data by the "needs love ratio",
+			// i.e. sort by ascending "needs love ratio" starting from index 0
+			// The smallest ratios indicate the most "love needed"
+			monetizedOriginDataList.sort((a, b) => {
+				const needsLoveRatioA = a.originVisitData.timeSpentAtOrigin / a.originVisitData.numberOfVisits;
+				const needsLoveRatioB = b.originVisitData.timeSpentAtOrigin / b.originVisitData.numberOfVisits;
+				const ratioComparison = needsLoveRatioA / needsLoveRatioB;
+
+				// If Array.prototype.sort() returns 0, 'b' and 'a' will be unchanged with respect to one another
+				let sortResult = 0;
+
+				if ((ratioComparison >= NEEDS_LOVE_MAGIC_NUMBER - NEEDS_LOVE_MAGIC_NUMBER_MARGIN)
+					&& (ratioComparison <= NEEDS_LOVE_MAGIC_NUMBER)
+				) {
+					if (a.originVisitData.numberOfVisits > b.originVisitData.numberOfVisits) {
+						// If origin 'a' has a slightly smaller needsLoveRatio but has more visits,
+						// origin 'b' actually needs more love since the person has spent only a marginally
+						// larger amount of time on the site, but with fewer visits. We should encourage
+						// them to visit 'b' more!
+
+						// If Array.prototype.sort() returns > 0, 'b' will be placed before 'a' in the array
+						return 1;
+					} else {
+						// Otherwise, if origin 'a' has a smaller needsLoveRatio AND less visits, then
+						// it definitely needs more love than 'b'.
+
+						// If Array.prototype.sort() returns < 0, 'a' will be placed before 'b' in the array
+						return -1;
+					}
+				} else {
+					// Sort as usual, place the origin with the smaller ratio before the other one
+					sortResult = needsLoveRatioA - needsLoveRatioB;
+				}
+				return sortResult;
+			});
+
+			listSize = (listSize < monetizedOriginDataList.length) ? listSize : monetizedOriginDataList.length;
+			topOriginsList = monetizedOriginDataList.slice(0, listSize);
+		} else {
+			topOriginsList = monetizedOriginDataList;
+		}
+	}
+
+	return topOriginsList;
+}
+
+/**
+ * Get all the monetized originData objects in a list.
+ * 
+ * @return {Promise<[AkitaOriginData]>} Resolves to a list of monetized AkitaOriginData objects.
+ */
+async function getMonetizedOriginDataList() {
+	const originDataList = await getOriginDataList();
+
+	let monetizedOriginDataList = null;
+
+	if (originDataList !== null) {
+		monetizedOriginDataList = originDataList.filter((originData) => originData.isCurrentlyMonetized);
+	}
+
+	return monetizedOriginDataList;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -185,7 +185,13 @@
         </object>Welcome</a>
     </section>
 
-
+    <script src="../data/WebMonetizationAsset.js"></script>
+    <script src="../data/AkitaPaymentPointerData.js"></script>
+    <script src="../data/AkitaOriginVisitData.js"></script>
+    <script src="../data/AkitaOriginData.js"></script>
+    <script src="../data/AkitaOriginStats.js"></script>
+    <script src="../data/storage.js"></script>
+    <script src="../main.js"></script>
     <script type="text/javascript" src="../../library/flickity.min.js"></script>
     <script src="popup.js"></script>
 </body>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -91,3 +91,28 @@ function ConvertMSToNiceTimeString(ms) {
     }
     return `${ms}ms`;
 }
+
+getStats();
+
+async function getStats() {
+	console.log("origin stats", await loadOriginStats());
+
+	const monetizedOriginDataList = await getMonetizedOriginDataList()
+	console.log("monetized origin data list", monetizedOriginDataList);
+	console.log("origin data list", await getOriginDataList());
+
+	for (const i in monetizedOriginDataList) {
+		const origin = monetizedOriginDataList[i].origin;
+		console.log("estimated payment to origin", origin, "$", await getEstimatedPaymentForOriginUSD(origin), "USD");
+	}
+
+	const originStats = await loadOriginStats();
+	console.log("origin stats", originStats);
+	console.log("percentage of monetized origin time spent", await getMonetizedTimeSpentPercent(originStats), "%");
+	console.log("percentage of monetized origin visits ", await getMonetizedVisitsPercent(originStats), "%");
+	
+	console.log("number of origins visited", await getNumberOfOriginsVisited());
+	console.log("number of monetized origins visited", await getNumberOfMonetizedOriginsVisited());
+	console.log("top origins by time spent", await getTopOriginsByTimeSpent());
+	console.log("top origins by love needed", await getTopOriginsThatNeedSomeLove());
+}


### PR DESCRIPTION
Fixes: #29, fixes: #18 

Add a bunch of calculations and functions to grab data for display in popup UI, contained in `main.js`.

See `getStats()` in popup.js for examples.

- calculate top 5 monetized sites - top 5 is determined by total amount spent at that origin
- percentage of monetized time out of total time
   - calculate total time spent across all sites
   - calculate total monetized time spent across all sites
- percentage of monetized visits out of total visits
   - calculate total visits across all sites
   - calculate total monetized visits across all sites
- calculate total payment streamed (per currency)
- figure out sites that could "use a little more love"
   - monetized sites that a user visits a lot, but doesn't spend very much time at