### PR TITLE
Hide needs love by default until monetized site visited

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -18,11 +18,11 @@
 			which is <strong id="monetized-percent-data" style="font-size: 18px;">15.2%</strong> of your time online.
 			In total, <span id="monetized-sent-text" style="font-size: 18px;">you’ve streamed</span> <strong id="monetized-sent-data">0.0078XRP</strong>.
 		</p>
-		<div id="sites-need-love-container">
+		<div id="sites-need-love-container" style="display: none;">
 			<h1 class="tooltip">These monetized sites could use ♥️</h1>
 			<div class="tooltip-bubble-left">These are sites which you visit often, but do not spend much time on.</div>
 		</div>
-		<div class="link-grid" style="margin-top: 25px;">
+		<div id="no-provider-resources-container" class="link-grid" style="margin-top: 25px;">
 			<a href="https://dev.to/dog-s/how-can-you-support-websites-without-having-to-deal-with-annoying-ads-3lmb" class="tooltip" style="background: #C47233;">How can you support websites without having to deal with annoying ads?</a>
 			<div class="tooltip-bubble-left" style="top: 450px;">Why does Web Monetization matter?</div>
 			<a href="https://coil.com/creator/how-to-monetize" class="tooltip" style="background: #C47233;">Monetize your own website or creative content with Coil</a>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -94,10 +94,12 @@ async function getStats() {
 		document.getElementById('info-container').innerHTML = `You haven't visited any websites yet! What are you waiting for? Get out there and explore the wild wild web.`;
 	}
 
+	const needsLoveContainer = document.getElementById('sites-need-love-container');
+	const noProviderResourcesContainer = document.getElementById('no-provider-resources-container');
+
 	if (originStats.totalSentAssetsMap?.XRP?.amount > 0) {
-		const needsLoveContainer = document.getElementById('sites-need-love-container');
-		const linkGrid = document.getElementsByClassName('link-grid')[0];
-		linkGrid.style.display = 'none';
+		noProviderResourcesContainer.style.display = 'none';
+		needsLoveContainer.style.display = 'block';
 
 		const needLoveOrigins = await getTopOriginsThatNeedSomeLove(3);
 
@@ -129,7 +131,7 @@ async function getStats() {
 			needsLoveContainer.appendChild(el);
 		}
 	} else {
-		const needsLoveContainer = document.getElementById("sites-need-love-container");
+		noProviderResourcesContainer.style.display = 'grid';
 		needsLoveContainer.style.display = 'none';
 	}
 


### PR DESCRIPTION
Hide the needs love div until a monetized site is visited. Until a monetized site is visited for the first time since installation of the browser extension, show the resources for a non-monetization
provider user. Hide the resources if the user is using a provider, otherwise keep displaying the resource blocks for someone not using a Web Monetization provider.

Related: #48 

Note that the tooltip location does not dynamically change with the location of the resource block, since the tooltips have their position hardcoded since #49 

