### PR TITLE
Add licensing info into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 ![Akita Icon](assets/documentation/akita_social_preview.png)
 
 # Akita
+
+[![Software License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Assets License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
+
 A browser extension that gives you insight into your involvement with [Web Monetization](https://webmonetization.org/).
 
 Akita presents your top visited monetized sites, how much time you’re spending on them, and how much you're contributing (or could contribute) to them.
 
-We've built this for the [Grant for the Web x DEV hackathon](https://res.cloudinary.com/practicaldev/image/fetch/s--aIp9TotN--/c_imagga_scale,f_auto,fl_progressive,h_500,q_auto,w_1000/https://dev-to-uploads.s3.amazonaws.com/i/q19vviykh0oi1s5tkbqe.png)!
+We've built this for the [Grant for the Web x DEV hackathon](https://dev.to/devteam/announcing-the-grant-for-the-web-hackathon-on-dev-3kd1)! We're so thrilled to have received a Runner Up Award for this project 🎉 - [Winners Announcement](https://dev.to/devteam/announcing-the-grant-for-the-web-x-dev-hackathon-winners-1nl4).
+
+Our license information can be found [here](docs/LicenseInfo.md) and our license/copyright notices can be found in [LICENSE](LICENSE).
 
 ---
 
@@ -23,7 +29,7 @@ We've built this for the [Grant for the Web x DEV hackathon](https://res.cloudin
 ---
 
 ## Installing
-Check out the instructions to install from source [here](docs/InstallAkita.md). We plan to put Akita on browser extension stores soon - please stay tuned. :)
+Check out the instructions to install from source or package [here](docs/InstallAkita.md). We are working on making Akita available in browser extension/add-on stores - please stay tuned. :)
 
 ---
 
@@ -82,7 +88,7 @@ Because of these hurdles, it can be difficult to see the value and broad potenti
 
 If you’re looking to start supporting websites by streaming payment, Akita will give you a good idea of which sites you can directly support through Web Monetization. If you’re already using a Web Monetization payment provider, Akita gives you insight into your contributions to the website by showing you the time spent on the site and the amount of payment streamed as a result.
 
-As Web Monetization becomes more common on websites, you’ll be able to see the evolution through Akita. We hope to see your favourite sites join the Web Monetization community! All of the data collected about your browsing and streamed payments is stored in local browser storage, so **all of this information stays in your hands**. 
+As Web Monetization becomes more common on websites, you’ll be able to see the evolution through Akita. We hope to see your favourite sites join the Web Monetization community! All of the data collected about your browsing and streamed payments is stored in local browser storage, so **all of this information stays in your hands**.
 
 Overall, our goal with Akita is to increase Web Monetization exposure and awareness, and to help people understand how Web Monetization fits in with their regular browsing. We want to give people who aren’t using a Web Monetization provider a way to engage in payment streaming. As more Web Monetization providers pop up, users can choose providers that fit their needs based on the browsing data presented by Akita.
 
@@ -94,7 +100,7 @@ Overall, our goal with Akita is to increase Web Monetization exposure and awaren
 5. [Akita: Get Involved in Web Monetization With or Without the Price Tag](https://dev.to/dog-s/akita-get-involved-in-web-monetization-with-or-without-the-price-tag-cd8) (Hackathon Submission Post)
 
 ### Why 'Akita'?
-Naming projects can be pretty challenging. We spent a good chunk of time coming up with various names before deciding to stay true to our "brand" as _dog-s_ and selecting "Akita" as our project name. 
+Naming projects can be pretty challenging. We spent a good chunk of time coming up with various names before deciding to stay true to our "brand" as _dog-s_ and selecting "Akita" as our project name.
 
 The Akita is a Japanese dog breed known for its loyalty and dedication. It's also quite fluffy. We were drawn to "Akita" because of the values the breed represents (i.e. loyalty, dedication), as those characteristics are what we want to embrace with our project. Through Akita and Web Monetization, we want to enable mutual loyalty and dedication between content creators/websites and their users.
 

--- a/docs/InstallAkita.md
+++ b/docs/InstallAkita.md
@@ -2,6 +2,15 @@
 
 Akita has been tested in Mozilla Firefox and Google Chrome. Instructions to install on these browsers is provided below. We hope to release Akita to browser extension stores in the near future.
 
+Our license information can be found [here](LicenseInfo.md) and our license/copyright notices can be found in [LICENSE](../LICENSE).
+
+## Table of Contents
+  - [Step 1: Download Akita Source](#step-1-download-akita-source)
+  - [Step 2, Option 1: Install Akita in Your Browser from Source](#step-2-option-1-install-akita-in-your-browser-from-source)
+  - [Step 2, Option 2: Install Akita in Your Browser from Package](#step-2-option-2-install-akita-in-your-browser-from-package)
+
+---
+
 ## Step 1: Download Akita Source
 From your preferred directory, run the command:
 
@@ -9,7 +18,7 @@ From your preferred directory, run the command:
 
 Note the path to the newly created `akita` directory.
 
-## Step 2: Install Akita in Your Browser
+## Step 2, Option 1: Install Akita in Your Browser from Source
 
 ### Installing Akita in Google Chrome
 1. In your Chrome address bar, type in `chrome://extensions/`. Press enter.
@@ -28,7 +37,9 @@ Some notes for Firefox:
 - Since Akita is installed as a temporary add-on, it only stays until you restart Firefox.
 - If you're feeling extra crafty, you can also install Akita using [web-ext](https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/).
 
-## Package Akita into a .zip
+## Step 2, Option 2: Install Akita in Your Browser from Package
+
+### Package Akita into a .zip
 1. Make sure you have the command-line tools `bash` and `zip` installed.
 2. From the akita directory, run `bash ./packageAkita.sh`.
 3. The resulting file akita.zip can be loaded into Firefox and Chrome.
@@ -44,3 +55,6 @@ Some notes for Firefox:
 2. Click on "Load Temporary Add-on...". A system file selection window should open.
 3. In the selection window, select `akita.zip`
 4. Akita is now installed - you should see the Akita extension icon in your browser bar!!
+
+A note for Firefox:
+- Since Akita is installed as a temporary add-on, it only stays until you restart Firefox.

--- a/docs/LicenseInfo.md
+++ b/docs/LicenseInfo.md
@@ -1,0 +1,18 @@
+# Akita License Info
+
+We want to make it easy for anyone to get involved with Akita, so we've licensed our project under two permissive licenses.
+
+We've chosen the MIT License for our software (i.e. code/documentation) and the Creative Commons Attribution 4.0 International Public License (CC BY 4.0) for any of the assets we create (generally found in [assets](../assets) and any subdirectories).
+
+Licenses can be a bit intimidating, but we've chosen the ones we think make it easiest for you to leverage Akita.
+
+_The short explanations below are meant to make the licenses more understandable and are **not** a substitute for the actual licenses._
+
+| Project Component | License | Short Explanation
+|:---:|:---:|---|
+| Software | [![Software License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) | [Adapted from tl;drLegal:](https://tldrlegal.com/license/mit-license)<br>You can use our software and related<br>documentation as long as you include<br>[our original copyright and license<br>notices](../LICENSE) in any copy of our software<br>or related documentation. |
+| Assets | [![Assets License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/) | [Adapted from tl;drLegal:](https://tldrlegal.com/license/creative-commons-attribution-4.0-international-(cc-by-4))<br>Distribute, remix, adapt, and build<br>upon our work, as long as you credit<br>us for the original creation, including<br>a URI/hyperlink to our work, [our <br>license and our copyright notice](../LICENSE).|
+
+For our copyright and license notices, please refer to our [LICENSE](../LICENSE) file.
+
+Essentially, just include our [LICENSE](../LICENSE) file and link to this repo if you end up using our code, documentation or assets. :)


### PR DESCRIPTION
Include licensing info (MIT, CC) in our README, with short explanations so they're easier to understand. Noted that the short explanations are not a substitute for the actual licenses, which are legal documents.

Also fixed the hackathon URL and added the Winners Announcement link as well.