### PR TITLE
Add periodic tracking and periodic validation for payment pointers

### DIFF
--- a/src/data/AkitaOriginData.js
+++ b/src/data/AkitaOriginData.js
@@ -54,6 +54,7 @@ class AkitaOriginData {
 	/**
 	 * @param {{
 	 *	paymentPointer: String,
+	 *	validationTimestamp: Number,
 	 *	amount?: Number,
 	 *	assetScale?: Number,
 	 *	assetCode?: String
@@ -61,7 +62,9 @@ class AkitaOriginData {
 	 *	 This object may be created, or a Web Monetization event detail object can be used.
 	 *	 Pass in an object with just a paymentPointer to register a payment pointer for
 	 *	 the current website. Payment pointer should be validated first.
-	 *	 Additionally pass in assetCode, assetScale, and amount together to add to the
+	 *	 Optionally pass in validationTimestamp to set when the payment pointer was most
+	 *	 recently validated.
+	 *	 Optionally pass in assetCode, assetScale, and amount together to add to the
 	 *	 total amount sent to the current website.
 	 *
 	 *	 assetCode e.g. 'XRP', 'USD', 'CAD'
@@ -74,7 +77,7 @@ class AkitaOriginData {
 	updatePaymentData(paymentData) {
 		if (paymentData) {
 			const paymentPointer = paymentData.paymentPointer;
-			
+
 			if (paymentPointer) {
 				this.isCurrentlyMonetized = true;
 
@@ -82,6 +85,14 @@ class AkitaOriginData {
 					this.paymentPointerMap[paymentPointer] = new AkitaPaymentPointerData(paymentPointer);
 				}
 
+				// Handling for optional argument: validationTimestamp
+				const validationTimestamp = paymentData.validationTimestamp;
+
+				if (validationTimestamp) {
+					this.paymentPointerMap[paymentPointer].setValidationTimestamp(validationTimestamp);
+				}
+
+				// Handling for the 3 optional arguments: amount, assetScale, and assetCode
 				const amount = paymentData.amount;
 				const assetScale = paymentData.assetScale;
 				const assetCode = paymentData.assetCode;

--- a/src/data/AkitaPaymentPointerData.js
+++ b/src/data/AkitaPaymentPointerData.js
@@ -4,6 +4,11 @@
  */
 class AkitaPaymentPointerData {
 	paymentPointer = null;
+
+	// The most recent time (UTC timestamp) when Akita validated the payment pointer
+	// For more info on payment pointer validation: see ../content_main.js, function isPaymentPointerValid
+	validationTimestamp = null;
+
 	// The type of each entry in sentAssetsMap is: WebMonetizationAsset
 	sentAssetsMap = {};
 
@@ -21,6 +26,7 @@ class AkitaPaymentPointerData {
 	 */
 	static fromObject(akitaPaymentPointerDataObject) {
 		const newPaymentPointerData = new AkitaPaymentPointerData(akitaPaymentPointerDataObject.paymentPointer);
+		newPaymentPointerData.validationTimestamp = akitaPaymentPointerDataObject.validationTimestamp;
 
 		for (const assetCode in akitaPaymentPointerDataObject.sentAssetsMap) {
 			newPaymentPointerData.sentAssetsMap[assetCode] = WebMonetizationAsset.fromObject(
@@ -28,6 +34,20 @@ class AkitaPaymentPointerData {
 			);
 		}
 		return newPaymentPointerData;
+	}
+
+	/**
+	 * When Akita validates a payment pointer, the time it was validated should be set using this
+	 * function. It is expected that payment pointers are validated by Akita often. In order to make
+	 * sure that validation occurs often, we keep track of the last time the payment pointer was
+	 * validated using validationTimestamp.
+	 *
+	 * For more info on payment pointer validation: see ./main.js, function isPaymentPointerValid
+	 *
+	 * @param {Number} validationTimestamp UTC Timestamp of last time payment pointer was validated.
+	 */
+	setValidationTimestamp(validationTimestamp) {
+		this.validationTimestamp = validationTimestamp;
 	}
 
 	/**

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -85,11 +85,12 @@ async function storeDataIntoAkitaFormat(data, typeOfData) {
 
 /**
  * Update payment data in originData and in originStats.
- * 
+ *
  * @param {AkitaOriginData} originData The origin data to update.
  * @param {AkitaOriginStats} originStats The origin stats to update.
  * @param {{
  *	paymentPointer: String,
+ *	validationTimestamp: Number,
  *	amount?: Number,
  *	assetScale?: Number,
  *	assetCode?: String
@@ -97,6 +98,8 @@ async function storeDataIntoAkitaFormat(data, typeOfData) {
  * 	 This object may be created, or a Web Monetization event detail object can be used.
  * 	 Pass in an object with just a paymentPointer to register a payment pointer for
  * 	 the current website. Payment pointer should be validated first.
+ *	 Optionally pass in validationTimestamp to set when the payment pointer was most
+ *	 recently validated.
  * 	 Additionally pass in assetCode, assetScale, and amount together to add to the
  * 	 total amount sent to the current website.
  */


### PR DESCRIPTION
## Related Issues
Closes #17 
~I expect that this PR also fixes (#76), but that needs to be verified.~

## Summary of Changes
- adds some logic in a `setinterval` which repeatedly checks if there is a new payment pointer on the current page. 
- adds a listener to the `visibilitychange` which updates the browser extension icon to the correct state when switching between tabs.
- adds a `validationTimestamp` field to the `AkitaPaymentPointerData` class to facilitate verifying if a payment pointer was validated recently.

## Explanation of Added Features
### Tracking and validating payment pointer if it changes on the current page
If a new payment pointer is encountered on the page and it has not been validated recently then it will be validated. If the validation is successful or if the payment pointer was already validated recently, the browser extension icon is set to the monetized state, otherwise it is set to the un-monetized state.

### Setting extension icon correctly when switching between tabs
When switching between tabs, the payment pointer on the new tab is validated if it has not been validated recently. If the validation is successful or if the payment pointer was already validated recently, the browser extension icon is set to the monetized state, otherwise it is set to the un-monetized state.

Also note that payment pointers are no longer stored in browser storage if they fail validation.