### PR TITLE
Fix favicon loading blocking popup opening by lazy-loading favicons

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -270,3 +270,14 @@ section {
 	margin-left: -5px;
 	margin-bottom: -5px;
 }
+
+.favicon {
+	height: 16px;
+	width: 16px;
+	border-radius: 50%;
+}
+
+/* Hide lazy-loaded favicons before they have a src because chrome gives them an ugly border */
+.favicon[src=''], .favicon:not([src]) {
+	opacity: 0;
+}

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -230,14 +230,13 @@ async function getStats() {
 
 function createFaviconImgElement(faviconSource) {
 	const faviconEl = document.createElement('img');
-	faviconEl.src = faviconSource;
+	faviconEl.classList.add('favicon');
 
-	// Set height and width to standard favicon size
-	faviconEl.width = 16;
-	faviconEl.height = 16;
-
-	// Make favicon round
-	faviconEl.style.borderRadius = "50%";
+	// Lazy-load the image in javascript so that popup opening is not blocked by faviconEl loading
+	fetch(faviconSource).then(async (response) => {
+		const blob = await response.blob();
+		faviconEl.src = URL.createObjectURL(blob);
+	});
 
 	return faviconEl;
 }


### PR DESCRIPTION
Fixes the user experience problem in issue #54. We could still improve favicon loading time by caching the top favicons, but it's no longer a significant UX issue.

**The Problem:**
The browser waits for favicon images to load before opening the extension popup. This behavior results in the popup taking a while to open if the favicons take a while to load.

**The solution:**
Favicon images are `fetched` before being put into image elements on the page (lazy-loaded images). This prevents the browser for waiting for image elements to load.