### PR TITLE
Add info to README and popup tutorial about Akita user data

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Our license information can be found [here](docs/LicenseInfo.md) and our license
     - [How Akita Helps](#how-akita-helps)
     - [Blog Posts on Our Process](#blog-posts-on-our-process)
     - [Why 'Akita'?](#why-akita)
+    - [Akita Data](#akita-data)
   - [Connect with Us](#connect-with-us)
 
 ---
@@ -105,6 +106,18 @@ Naming projects can be pretty challenging. We spent a good chunk of time coming 
 The Akita is a Japanese dog breed known for its loyalty and dedication. It's also quite fluffy. We were drawn to "Akita" because of the values the breed represents (i.e. loyalty, dedication), as those characteristics are what we want to embrace with our project. Through Akita and Web Monetization, we want to enable mutual loyalty and dedication between content creators/websites and their users.
 
 We were also very inspired by the story of [Hachikō](https://en.wikipedia.org/wiki/Hachik%C5%8D) - a dog of immense loyalty. Hachikō was an Akita who would meet with his owner every day at the train station. Even after his owner passed away, Hachikō continued to wait for his owner at the train station for more than 9 years. Hachikō continues to have a legacy in Japanese culture, with various statues created in his memory - there was even an [American film](https://en.wikipedia.org/wiki/Hachi:_A_Dog%27s_Tale) based on him.
+
+### Akita Data
+Akita collects data on
+
+- your time spent and number of visits on all websites,
+- the [Payment Pointers](https://paymentpointers.org/) present on the websites you visit,
+- and the currency and amount of payments streamed to Payment Pointers via Web Monetization.
+
+You can view an example of the data collected by Akita in [`examples/example_data.json`](examples/example_data.json).
+The data collected by Akita is stored on your machine, in your browser's local storage.
+Your data stays in your hands: it is not backed up, shared, or uploaded anywhere.
+Therefore, if you uninstall the Akita browser extension, your data will be **permanently deleted** and will not be recoverable.
 
 ---
 

--- a/src/popup/carousel.css
+++ b/src/popup/carousel.css
@@ -1,7 +1,7 @@
 #carousel {
 	height: 500px;
 	display: grid;
-	grid-template-columns: repeat(6, 100%);
+	grid-template-columns: repeat(7, 100%);
 }
 #intro-exit {
 	position: absolute;
@@ -51,7 +51,7 @@
 	bottom: 25px;
 	left: 113px;
 	width: 185px;
-	grid-template-columns: repeat(6, minmax(0, 1fr));
+	grid-template-columns: repeat(7, minmax(0, 1fr));
 }
 
 .carousel-dot {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -132,12 +132,23 @@
 					data="../../assets/demo_unmon.svg"
 					style="height: 100px;">
 				</object>
-				<p>Thank you for reading.</p>
+			</div>
+			<div class="carousel-slide">
+				<h2>About Your Data</h2>
+				<p>Akita collects data on</p>
+				<ul style="line-height: normal;">
+					<li>your time spent and number of visits on all websites,</li>
+					<li>the <a href="https://paymentpointers.org/">Payment Pointers</a> present on the websites you visit,</li>
+					<li>and the currency and amount of payments streamed to Payment Pointers via Web Monetization.</li>
+				</ul>
+				<p>The data collected by Akita is stored locally on your computer, so all of this data stays in your hands.</p>
+				<p>If you uninstall the Akita browser extension, your data will be <strong>permanently deleted</strong> and will not be recoverable.</p>
 			</div>
 		</div>
 		<div id="intro-exit">skip</div>
 		<img src="../../assets/next-button.svg" id="left-button"></object>
 		<div id="carousel-dot-container">
+			<div class="carousel-dot"></div>
 			<div class="carousel-dot"></div>
 			<div class="carousel-dot"></div>
 			<div class="carousel-dot"></div>


### PR DESCRIPTION
Closes #81 

Added info about the user data that Akita stores, the fact that the data is stored locally, and the fact that uninstalling the extension will permanently delete your data. The added README and popup information are not the exact same because, prior to this PR, the README already said that 

>  All of the data collected about your browsing and streamed payments is stored in local browser storage, so **all of this information stays in your hands**.

while the Akita tutorial did not say this. The README also links to `examples/example_data.json` so that people browsing the repo can see an example of Akita data.