### PR TITLE
Track monetized and non-monetized time properly

### DIFF
--- a/examples/example_data.json
+++ b/examples/example_data.json
@@ -10,7 +10,6 @@
 		"totalTimeSpent": 1834971294872194719204821,
 		"totalMonetizedTimeSpent": 194719204821,
 		"totalVisits": 500,
-		"totalMonetizedVisits": 30,
 		"totalSentAssetsMap": {
 			"XRP": {
 				"amount": 74289471,
@@ -33,9 +32,8 @@
 		{
 			"origin":"https://dev.to",
 			"faviconSource": "https://dev-to.s3.us-east-2.amazonaws.com/favicon.ico",
-			"isCurrentlyMonetized":true,
 			"originVisitData":{
-				"timeSpentAtOrigin": 8731882,
+				"monetizedTimeSpent": 8731882,
 				"numberOfVisits": 3,
 				"dateOfFirstVisit": "2020-05-01",
 				"dateOfMostRecentVisit": "2020-06-02"
@@ -56,9 +54,8 @@
 		{
 			"origin":"https://www.twitch.tv",
 			"faviconSource": "https://static.twitchcdn.net/assets/favicon-16-2d5d1f5ddd489ee10398.png",
-			"isCurrentlyMonetized":true,
 			"originVisitData":{
-				"timeSpentAtOrigin": 4723893,
+				"monetizedTimeSpent": 4723893,
 				"numberOfVisits": 2,
 				"dateOfFirstVisit": "2020-05-15",
 				"dateOfMostRecentVisit": "2020-05-27"
@@ -89,9 +86,8 @@
 		{
 			"origin":"https://sdog.netlify.app",
 			"faviconSource": "https://sharonwang.netlify.app/favicon.ico",
-			"isCurrentlyMonetized":true,
 			"originVisitData":{
-				"timeSpentAtOrigin": 4567890218492,
+				"monetizedTimeSpent": 4567890218492,
 				"numberOfVisits": 300,
 				"dateOfFirstVisit": "2020-01-01",
 				"dateOfMostRecentVisit": "2020-06-02"

--- a/src/data/AkitaOriginData.js
+++ b/src/data/AkitaOriginData.js
@@ -11,7 +11,7 @@
 class AkitaOriginData {
 	origin = null;
 	faviconSource = null;
-	isCurrentlyMonetized = false;
+
 	// The type of each entry in paymentPointerMap is: AkitaPaymentPointerData
 	paymentPointerMap = {};
 
@@ -34,7 +34,6 @@ class AkitaOriginData {
 	static fromObject(akitaOriginDataObject) {
 		const newOriginData = new AkitaOriginData(akitaOriginDataObject.origin);
 		newOriginData.faviconSource = akitaOriginDataObject.faviconSource;
-		newOriginData.isCurrentlyMonetized = akitaOriginDataObject.isCurrentlyMonetized;
 
 		for (const paymentPointer in akitaOriginDataObject.paymentPointerMap) {
 			newOriginData.paymentPointerMap[paymentPointer] = AkitaPaymentPointerData.fromObject(
@@ -79,8 +78,6 @@ class AkitaOriginData {
 			const paymentPointer = paymentData.paymentPointer;
 
 			if (paymentPointer) {
-				this.isCurrentlyMonetized = true;
-
 				if (!this.paymentPointerMap[paymentPointer]) {
 					this.paymentPointerMap[paymentPointer] = new AkitaPaymentPointerData(paymentPointer);
 				}
@@ -101,9 +98,6 @@ class AkitaOriginData {
 					this.paymentPointerMap[paymentPointer].addAsset(amount, assetScale, assetCode);
 				}
 			}
-		} else {
-			// If paymentData is null then monetization is pending or was stopped
-			this.isCurrentlyMonetized = false;
 		}
 	}
 
@@ -115,12 +109,12 @@ class AkitaOriginData {
 	}
 
 	/**
-	 * Update time spent at the origin.
+	 * Update monetized time spent at the origin.
 	 *
-	 * @param {Number} recentTimeSpent The recent time spent at the origin.
+	 * @param {Number} recentMonetizedTimeSpent The recent monetized time spent at the origin.
 	 */
-	addTimeSpent(recentTimeSpent = 0) {
-		this.originVisitData.addTimeSpent(recentTimeSpent);
+	addMonetizedTimeSpent(recentMonetizedTimeSpent = 0) {
+		this.originVisitData.addMonetizedTimeSpent(recentMonetizedTimeSpent);
 	}
 
 	/**

--- a/src/data/AkitaOriginStats.js
+++ b/src/data/AkitaOriginStats.js
@@ -14,7 +14,6 @@ class AkitaOriginStats {
 	totalTimeSpent = 0;
 	totalMonetizedTimeSpent = 0;
 	totalVisits = 0;
-	totalMonetizedVisits = 0;
 
 	// The type of each entry in totalSentAssetsMap is: WebMonetizationAsset
 	totalSentAssetsMap = {};
@@ -33,7 +32,6 @@ class AkitaOriginStats {
 		newAkitaOriginStats.totalTimeSpent = akitaOriginStats.totalTimeSpent;
 		newAkitaOriginStats.totalMonetizedTimeSpent = akitaOriginStats.totalMonetizedTimeSpent;
 		newAkitaOriginStats.totalVisits = akitaOriginStats.totalVisits;
-		newAkitaOriginStats.totalMonetizedVisits = akitaOriginStats.totalMonetizedVisits;
 
 		for (const assetCode in akitaOriginStats.totalSentAssetsMap) {
 			newAkitaOriginStats.totalSentAssetsMap[assetCode] = WebMonetizationAsset.fromObject(
@@ -49,16 +47,16 @@ class AkitaOriginStats {
 	 ***********************************************************/
 
 	/**
-	 * Update the total monetized time spent if the origin is monetized; update
+	 * Update the total monetized time spent if the time was monetized; update
 	 * the total time spent regardless.
 	 *
 	 * @param {Number} recentTimeSpent The new amount of time spent at the origin.
-	 * @param {Boolean} originIsCurrentlyMonetized Whether the origin is monetized or not.
+	 * @param {Boolean} isMonetizedTime Whether the time spent is monetized or not.
 	 */
-	updateTimeSpent(recentTimeSpent, originIsCurrentlyMonetized) {
+	updateTimeSpent(recentTimeSpent, isMonetizedTime) {
 		this.updateTotalTimeSpent(recentTimeSpent);
 
-		if (originIsCurrentlyMonetized) {
+		if (isMonetizedTime) {
 			this.updateTotalMonetizedTimeSpent(recentTimeSpent);
 		}
 	}
@@ -75,7 +73,7 @@ class AkitaOriginStats {
 	/**
 	 * Update the total time spent at monetized origins.
 	 *
-	 * @param {Number} recentTimeSpent The new amount of time spent at the origin.
+	 * @param {Number} recentTimeSpent The new amount of monetized time spent.
 	 */
 	updateTotalMonetizedTimeSpent(recentTimeSpent) {
 		this.totalMonetizedTimeSpent += recentTimeSpent;
@@ -86,30 +84,10 @@ class AkitaOriginStats {
 	 ***********************************************************/
 
 	/**
-	 * Update the total visits to monetized origins if the origin is monetized,
-	 * and update the total visits to origins regardless.
-	 *
-	 * @param {Boolean} originIsCurrentlyMonetized Whether the origin is monetized or not.
-	 */
-	incrementVisits(originIsCurrentlyMonetized) {
-		if (originIsCurrentlyMonetized) {
-			this.incrementTotalMonetizedVisits();
-		}
-		this.incrementTotalVisits();
-	}
-
-	/**
 	 * Increment the total visits to origins.
 	 */
 	incrementTotalVisits() {
 		this.totalVisits += 1;
-	}
-
-	/**
-	 * Increment the total visits to monetized origins.
-	 */
-	incrementTotalMonetizedVisits() {
-		this.totalMonetizedVisits += 1;
 	}
 
 	/***********************************************************

--- a/src/data/AkitaOriginVisitData.js
+++ b/src/data/AkitaOriginVisitData.js
@@ -10,7 +10,7 @@
  *   - date of most recent visit recorded in Akita (format: YYYY-MM-DD)
  */
 class AkitaOriginVisitData {
-	timeSpentAtOrigin = 0; // time in milliseconds
+	monetizedTimeSpent = 0; // time in milliseconds
 	numberOfVisits = 0;
 	dateOfFirstVisit = "";
 	dateOfMostRecentVisit = "";
@@ -28,7 +28,7 @@ class AkitaOriginVisitData {
 
 		if (akitaOriginVisitDataObject) {
 			newOriginVisitData = new AkitaOriginVisitData();
-			newOriginVisitData.timeSpentAtOrigin = akitaOriginVisitDataObject.timeSpentAtOrigin;
+			newOriginVisitData.monetizedTimeSpent = akitaOriginVisitDataObject.monetizedTimeSpent;
 			newOriginVisitData.numberOfVisits = akitaOriginVisitDataObject.numberOfVisits;
 			newOriginVisitData.dateOfFirstVisit = akitaOriginVisitDataObject.dateOfFirstVisit;
 			newOriginVisitData.dateOfMostRecentVisit = akitaOriginVisitDataObject.dateOfMostRecentVisit;
@@ -38,12 +38,12 @@ class AkitaOriginVisitData {
 	}
 
 	/**
-	 * Update the total time spent by adding the recent time to the total.
+	 * Update the total monetized time spent by adding the recent monetized time to the total.
 	 *
-	 * @param {Number} recentTimeSpentAtOrigin The new amount of time spent at the origin.
+	 * @param {Number} recentMonetizedTimeSpentAtOrigin The new amount of monetized time spent at the origin.
 	 */
-	addTimeSpent(recentTimeSpentAtOrigin = 0) {
-		this.timeSpentAtOrigin += recentTimeSpentAtOrigin;
+	addMonetizedTimeSpent(recentMonetizedTimeSpentAtOrigin = 0) {
+		this.monetizedTimeSpent += recentMonetizedTimeSpentAtOrigin;
 	}
 
 	/**

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -68,7 +68,7 @@ async function getStats() {
 	const originStats = await loadOriginStats();
 	const circleContainer = document.getElementById('circle-container');
 
-	if (!originStats || originStats.totalMonetizedVisits < 1) {
+	if (!originStats || originStats.totalMonetizedTimeSpent === 0) {
 		// The user has not visisted a monetized site yet
 		document.getElementById('circle-empty-illustration').style.display = 'block';
 		circleContainer.style.display = 'none';
@@ -77,7 +77,7 @@ async function getStats() {
 		return;
 	}
 
-	if (originStats && originStats.totalMonetizedVisits > 0) {
+	if (originStats && originStats.totalMonetizedTimeSpent > 0) {
 		// If the user has visisted at least 1 monetized site, display monetization data
 		document.getElementById('monetized-time-data').innerHTML = convertMSToNiceTimeString(originStats.totalMonetizedTimeSpent);
 
@@ -145,7 +145,7 @@ async function getStats() {
 		const topOrigins = await getTopOriginsByTimeSpent(5);
 		let circleWeights = [];
 		for (const originData of topOrigins) {
-			const timeSpent = originData?.originVisitData.timeSpentAtOrigin;
+			const timeSpent = originData?.originVisitData.monetizedTimeSpent;
 			circleWeights.push(timeSpent);
 		}
 
@@ -247,16 +247,16 @@ function createTopSiteCircleHTML(originData, totalSentXRP) {
 	const visitText = (visitData.numberOfVisits === 1) ? "visit" : "visits";
 
 	if (totalSentXRP > 0) {
-		return `${convertMSToNiceTimeString(visitData.timeSpentAtOrigin)}<br>${totalSentXRP.toFixed(3)} XRP<br>${visitData.numberOfVisits} ` + visitText;
+		return `${convertMSToNiceTimeString(visitData.monetizedTimeSpent)}<br>${totalSentXRP.toFixed(3)} XRP<br>${visitData.numberOfVisits} ` + visitText;
 	} else {
-		return `${convertMSToNiceTimeString(visitData.timeSpentAtOrigin)}<br>${visitData.numberOfVisits} ` + visitText;
+		return `${convertMSToNiceTimeString(visitData.monetizedTimeSpent)}<br>${visitData.numberOfVisits} ` + visitText;
 	}
 }
 
 function createTopSiteDetailHTML(originData, totalSentXRP, originStats) {
 	if (!originData || !originStats) return "";
 
-	const timeSpent = originData.originVisitData.timeSpentAtOrigin;
+	const timeSpent = originData.originVisitData.monetizedTimeSpent;
 	let sentPayment = totalSentXRP.toFixed(3);
 	let paymentString = "So far, you've sent";
 	if (parseFloat(sentPayment) > 0) {
@@ -279,7 +279,7 @@ function createTopSiteDetailHTML(originData, totalSentXRP, originStats) {
 	const percentVisits = getPercentVisitsToOriginOutOfTotal(originData, originStats);
 
 	return `<a href="${origin}" style="color: black; text-decoration: underline;">${origin}</a><br><br>
-		You've spent <strong>${convertMSToNiceTimeString(timeSpent)}</strong> here, which is <strong>${percentTimeSpent}%</strong> of your time online.<br><br>
+		You've spent <strong>${convertMSToNiceTimeString(timeSpent)}</strong> of monetized time here, which is <strong>${percentTimeSpent}%</strong> of your time online.<br><br>
 		You've visited <strong>${visitCountText}</strong>, which is <strong>${percentVisits}%</strong> of your total website visits.<br><br>
 		${paymentString} <strong>${sentPayment}</strong> to this site.`;
 }


### PR DESCRIPTION
Fixes: #79 

Previously, we assumed that as soon as we see a payment pointer on a website (at an origin), that the origin is always considered to be monetized. So, once we decided that an origin is monetized, any time spent on the site was considered monetized time spent on the site. However, this is a flawed assumption, since sites such as YouTube may only contain payment pointers (meta tags) on specific videos and not others. So, some of the time spent on the site is monetized and some is non-monetized. This PR updates how we track time by checking for a payment pointer as we track time, to store
time spent properly.

We no longer store detailed data for every single origin -- only monetized origins are stored. Additionally, counting monetized
visits and associated functions have been removed as they were not being used or were redundant. The `isCurrentlyMonetized` field has been removed from AkitaOriginData as it was a major part of the problematic monetized time tracking. The text in the top site detail has been updated to point out that the time is monetized time, just to be clear.