### PR TITLE
Support displaying various currencies instead of just XRP

### DIFF
--- a/src/data/AkitaOriginData.js
+++ b/src/data/AkitaOriginData.js
@@ -125,4 +125,39 @@ class AkitaOriginData {
 	storeOriginFavicon(faviconPath) {
 		this.faviconSource = faviconPath;
 	}
+
+	/**
+	 * Calculate the total sent assets at the origin for each currency sent to the payment
+	 * pointers seen at the origin and return the data as a map.
+	 *
+	 * @return {Map<String, Number>} A map containing the sent asset amounts, with the currency
+	 * as the key (String) and the sent amount as the value (Number).
+	 */
+	getTotalSentAssets() {
+		if (this.paymentPointerMap) {
+			let sentAssetsMap = new Map();
+
+			for (const paymentPointerData of Object.values(this.paymentPointerMap)) {
+				for (const sentAssetData of Object.values(paymentPointerData.sentAssetsMap)) {
+					const currency = sentAssetData.assetCode;
+					let amount = sentAssetData.toAmount();
+					const existingAmountForCurrency = sentAssetsMap.get(currency);
+
+					// If the currency for sent assets already exists in the map (for a
+					// different payment pointer), then add to the existing amount
+					if (existingAmountForCurrency) {
+						amount = existingAmountForCurrency + amount;
+					}
+
+					sentAssetsMap.set(currency, amount);
+				}
+			}
+
+			if (sentAssetsMap.size > 0) {
+				return sentAssetsMap;
+			}
+		}
+
+		return null;
+	}
 }

--- a/src/data/AkitaOriginStats.js
+++ b/src/data/AkitaOriginStats.js
@@ -91,7 +91,7 @@ class AkitaOriginStats {
 	}
 
 	/***********************************************************
-	 * Update Total Sent Assets Map
+	 * Total Sent Assets Map
 	 ***********************************************************/
 
 	/**
@@ -129,5 +129,29 @@ class AkitaOriginStats {
 			}
 			this.totalSentAssetsMap[assetCode].addAmount(amount, assetScale);
 		}
+	}
+
+	/**
+	 * Calculate the total sent assets across all origins for each currency sent to the payment
+	 * pointers seen and return the data as a map.
+	 *
+	 * @return {Map<String, Number>} A map containing the sent asset amounts, with the currency
+	 * as the key (String) and the sent amount as the value (Number).
+	 */
+	getTotalSentAssets() {
+		if (this.totalSentAssetsMap) {
+			let sentAssetsMap = new Map();
+
+			for (const sentAssetData of Object.values(this.totalSentAssetsMap)) {
+				const currency = sentAssetData.assetCode;
+				sentAssetsMap.set(currency, sentAssetData.toAmount());
+			}
+
+			if (sentAssetsMap.size > 0) {
+				return sentAssetsMap;
+			}
+		}
+
+		return null;
 	}
 }

--- a/src/data/WebMonetizationAsset.js
+++ b/src/data/WebMonetizationAsset.js
@@ -57,10 +57,25 @@ class WebMonetizationAsset {
 		this.amount += amount;
 	}
 
+	/**
+	 * Update the Web Monetization Asset's amount and assetScale to
+	 * reflect the new scale.
+	 *
+	 * @param {Number} newScale The new scale to use for the asset.
+	 */
 	convertAmountToNewAssetScale(newScale) {
 		const scaleDifference = newScale - this.assetScale;
 
-		this.amount * 10**scaleDifference;
+		this.amount *= 10**scaleDifference;
 		this.assetScale = newScale;
+	}
+
+	/**
+	 * Convert the Web Monetization Asset to its representative amount.
+	 *
+	 * @return {Number} The converted asset amount.
+	 */
+	toAmount() {
+		return (this.amount * (10**(-this.assetScale)));
 	}
 }

--- a/src/main.js
+++ b/src/main.js
@@ -153,44 +153,57 @@ function getEstimatedPaymentForTimeInUSD(timeSpent) {
 }
 
 /***********************************************************
- * Payment Streamed Calculation
+ * Amount of Payment Streamed (Sent Assets)
  ***********************************************************/
 
 /**
- * Calculate the total sent XRP across all origins.
+ * Convert the provided sentAssetsMap to a string.
+ * Example output: "20.20CAD, 0.67XRP and 123.45 USD"
  *
- * @return {Number} The total sent XRP across all origins.
+ * @param {Map<String, Number>} sentAssetsMap A map containing the sent asset amounts,
+ * with the currency as the key (String) and the sent amount as the value (Number).
+ * @param {Number} decimalPoints The AkitaOriginData to calculate sent assets for.
+ * @return {String} The sent assets formatted as a string.
  */
-async function calculateTotalSentXRP() {
-	const originDataList = await getOriginDataList();
-	let totalSentXRP = 0;
+function getSentAssetsMapAsString(sentAssetsMap, decimalPoints) {
+	let sentAssetsString = ``;
 
-	for (const originData in originDataList) {
-		totalSentXRP += calculateTotalSentXRPForOrigin(originData);
-	}
+	if (sentAssetsMap) {
+		let entriesToStringify = sentAssetsMap.size;
 
-	return unNaN(totalSentXRP);
-}
+		for (const [currency, amount] of sentAssetsMap.entries()) {
+			let amountSent = amount.toFixed(decimalPoints);
 
-/**
- * Calculate the total sent XRP for the specified origin.
- *
- * @param {AkitaOriginData} originData The AkitaOriginData to calculate sent XRP for.
- * @return {Number} The total sent XRP for the specified origin.
- */
-function calculateTotalSentXRPForOrigin(originData) {
-	let totalSentXRP = 0;
-
-	if (originData.paymentPointerMap) {
-		for (const paymentPointerData of Object.values(originData.paymentPointerMap)) {
-			if (paymentPointerData.sentAssetsMap?.XRP?.amount > 0) {
-				const sentXRP = paymentPointerData.sentAssetsMap.XRP;
-				const actualAmount = sentXRP.amount * (10**(-sentXRP.assetScale));
-				totalSentXRP += actualAmount;
+			// No need to display the amount if it's effectively zero
+			if (parseFloat(amountSent) === 0) {
+				continue;
 			}
+
+			let amountSentString = `<strong>${amountSent}<span style="font-size: 12px;">${currency}</span></strong>`;
+
+			// There's only one entry in the map
+			if (sentAssetsMap.size === 1) {
+				sentAssetsString = amountSentString;
+				break;
+			}
+
+			// There's more than one entry in the map
+			if (entriesToStringify >= 3) {
+				// There are at least 3 entries to stringify, so we'll use a comma to separate the entries
+				sentAssetsString += `${amountSentString}, `;
+			} else if ((sentAssetsMap.size > 1) && (entriesToStringify === 1)) {
+				// This is the entry left to stringify, so use 'and'
+				sentAssetsString += ` and ${amountSentString}`;
+			} else {
+				// There's a single entry remaining in the map
+				sentAssetsString += `${amountSentString}`;
+			}
+
+			entriesToStringify -= 1;
 		}
 	}
-	return unNaN(totalSentXRP);
+
+	return sentAssetsString;
 }
 
 /***********************************************************

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -20,7 +20,7 @@
 		<p id="info-container">
 			You’ve spent <strong id="monetized-time-data" style="font-size: 18px;">0 hours</strong> on monetized sites,
 			which is <strong id="monetized-percent-data" style="font-size: 18px;">0%</strong> of your time online.
-			In total, <span id="monetized-sent-text" style="font-size: 18px;">you’ve streamed</span> <strong id="monetized-sent-data">0XRP</strong>.
+			In total, <span id="monetized-sent-text" style="font-size: 18px;">you’ve streamed</span> <span id="monetized-sent-data"><strong>0XRP</strong></span>.
 		</p>
 		<div id="sites-need-love-container" style="display: none;">
 			<h1 class="tooltip">These monetized sites could use ♥️</h1>


### PR DESCRIPTION
Fixes: #97 

To keep things simple for our initial hackathon submission, we decided to only worry about displaying sent assets in XRP, as it was generally the default currency being used. However, on some sites (eg. YouTube), the assetCode used for streamed payment may not be XRP.

To support various currencies, I have made a few changes to the UI:
- top site circles no longer display amount of payment streamed in the circle, since multiple currencies could be at play and that would be too much text
    - I can change this to continue to display the amount of payment streamed in the circle ,if only one currency has ever been streamed to the origin, if that is preferred
- top site detail may contain a list of payments in different currencies that have been sent to the origin
- the main akita view will list various currencies streamed, if that has occurred

I have replaced our XRP-specific calculations with summing up the total payments being made in each currency for each origin.

Some screenshots to show the UI changes:
![image](https://user-images.githubusercontent.com/25834218/103338919-2fc78f00-4a3d-11eb-9c01-ade82a3052f1.png)
![image](https://user-images.githubusercontent.com/25834218/103338932-3ce47e00-4a3d-11eb-8400-b5be448aa5e3.png)