### PR TITLE
Add support for monetization in iframes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,6 @@
 	},
 	"permissions":[
 		"tabs",
-		"<all_urls>",
 		"storage"
 	],
 	"background": {
@@ -18,7 +17,7 @@
 	},
 	"content_scripts": [
 		{
-			"matches": ["<all_urls>", "http://*/*", "https://*/*"],
+			"matches": ["http://*/*", "https://*/*"],
 			"js": [
 				"src/data/WebMonetizationAsset.js",
 				"src/data/AkitaPaymentPointerData.js",
@@ -26,9 +25,18 @@
 				"src/data/AkitaOriginData.js",
 				"src/data/AkitaOriginStats.js",
 				"src/data/storage.js",
-				"src/content_main.js",
-				"src/main.js"
-			]
+				"src/content_scripts/content_general.js"
+			],
+			"all_frames":true
+		},
+		{
+			"matches": ["http://*/*", "https://*/*"],
+			"js": ["src/content_scripts/content_origin.js"]
+		},
+		{
+			"matches": ["http://*/*", "https://*/*"],
+			"js": ["src/content_scripts/content_iframe.js"],
+			"all_frames":true
 		}
 	],
 	"browser_action": {

--- a/src/background_script.js
+++ b/src/background_script.js
@@ -6,19 +6,29 @@ const UNMONETIZED_ICON_PATH = '../assets/icon_unmonetized.png';
 // Listen to messages sent from Content Scripts via webBrowser.runtime.sendMessage
 webBrowser.runtime.onMessage.addListener(
 	(request, sender, sendResponse) => {
+		// Set browser badge and icon based on requests sent from content_origin.js
 		if (request.isCurrentlyMonetized) {
-			webBrowser.browserAction.setBadgeBackgroundColor({ color: '#EF5E92' });
-			webBrowser.browserAction.setBadgeText({ text: '$' });
-			webBrowser.browserAction.setIcon({
-				path: MONETIZED_ICON_PATH,
+			const isCurrentlyMonetized = request.isCurrentlyMonetized.value;
+			if (isCurrentlyMonetized) {
+				webBrowser.browserAction.setBadgeBackgroundColor({ color: '#EF5E92' });
+				webBrowser.browserAction.setBadgeText({ text: '$' });
+				webBrowser.browserAction.setIcon({
+					path: MONETIZED_ICON_PATH,
+					tabId: sender.tab.id
+				});
+			} else {
+				webBrowser.browserAction.setBadgeText({ text: '' }); // Hide the badge
+				webBrowser.browserAction.setIcon({
+				path: UNMONETIZED_ICON_PATH,
 				tabId: sender.tab.id
-			});
-		} else {
-			webBrowser.browserAction.setBadgeText({ text: '' }); // Hide the badge
-			webBrowser.browserAction.setIcon({
-			path: UNMONETIZED_ICON_PATH,
-			tabId: sender.tab.id
-			});
+				});
+			}
+			return;
+		}
+		// Forward messages from content_iframe.js scripts to content_origin.js
+		if (request.iframePaymentPointerChange || request.iframeReceivedUuid) {
+			chrome.tabs.sendMessage(sender.tab.id, request);
+			return;
 		}
 	}
 );

--- a/src/content_scripts/content_general.js
+++ b/src/content_scripts/content_general.js
@@ -1,0 +1,54 @@
+/***********************************************************
+ * content_general.js runs both at the top level page (alongside content_origin.js), and
+ * in iframes (alongside content_iframe.js); it handles forwarding web monetization events into
+ * akita events.
+ ***********************************************************/
+
+const NEW_PAYMENT_POINTER_CHECK_RATE_MS = 1000; // 1 second
+const PAYMENT_POINTER_VALIDATION_RATE_MS = 1000 * 60 * 60; // 1 hour
+
+/**
+ * Content scripts can only see a "clean version" of the DOM, i.e. a version of the DOM without
+ * properties which are added by JavaScript, such as document.monetization!
+ * reference: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#Content_script_environment
+ *			  https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
+ * So we must inject some code into the JavaScript context of the current tab in order to
+ * access the document.monetization object. We inject code using a script element:
+ */
+const scriptEl = document.createElement('script');
+scriptEl.text = `
+	if (document.monetization) {
+		document.monetization.addEventListener('monetizationstart', (event) => {
+			document.dispatchEvent(new CustomEvent('akita_monetizationstart', { detail: event.detail }));
+		});
+
+		document.monetization.addEventListener('monetizationprogress', (event) => {
+			document.dispatchEvent(new CustomEvent('akita_monetizationprogress', { detail: event.detail }));
+		});
+
+		document.monetization.addEventListener('monetizationstop', (event) => {
+			document.dispatchEvent(new CustomEvent('akita_monetizationstop', { detail: event.detail }));
+		});
+	}
+`;
+document.body.appendChild(scriptEl);
+
+/**
+ * Gets the payment pointer as a string from the monetization meta tag on the current page.
+ * If there is no monetization meta tag on the page, null is returned.
+ *
+ * For more info on the monetization meta tag:
+ *	- https://webmonetization.org/docs/getting-started
+ *	- https://webmonetization.org/specification.html#meta-tags-set
+ *
+ * @return {string|null} The payment pointer on the current page, or null if no meta tag is present.
+ */
+function getPaymentPointerFromPage() {
+	const monetizationMetaTag = document.querySelector('meta[name="monetization"]');
+
+	if (monetizationMetaTag) {
+		return monetizationMetaTag.content;
+	} else {
+		return null;
+	}
+}

--- a/src/content_scripts/content_iframe.js
+++ b/src/content_scripts/content_iframe.js
@@ -1,0 +1,84 @@
+/***********************************************************
+ * content_iframe.js runs inside of each iframe and tracks and notifies content_origin.js of
+ * payment pointer changes in the iframe via the `webBrowser.runtime` message channel. Each
+ * content_iframe.js in each iframe is assigned a uuid from content_origin.js via postMessage so
+ * that content_origin.js can know which iframe the script is associated with when the script sends
+ * messages.
+ ***********************************************************/
+
+// window.isTopLevel is set to true in ./content_origin.js, which only runs in the top level page;
+// so if window.isTopLevel is not set to true, then this script is running in an iframe. All code
+// in content_iframe.js should be inside this if block.
+if (!window.isTopLevel) {
+
+    let topLevelOrigin = null;
+    let monetizationPaymentEvents = [];
+
+    document.addEventListener('akita_monetizationprogress', (event) => {
+        const monetizationPaymentEvent = event.detail;
+
+        // Payment events may be received by the iframe before the top level page communicates the
+        // topLevelOrigin to the iframe. However, since payment events are stored under the
+        // topLevelOrigin, the topLevelOrigin needs to be received before payment events are saved.
+        // Until a topLevelOrigin is received, payment events are put into an array for later storage.
+        if (topLevelOrigin === null) {
+            monetizationPaymentEvents.push(monetizationPaymentEvent);
+        } else {
+            storeDataIntoAkitaFormat(monetizationPaymentEvent, AKITA_DATA_TYPE.PAYMENT, topLevelOrigin);
+        }
+    });
+
+
+    // Listen for a message from the top level page (./content_origin.js).
+    // The iframe expects to receive a uuid and origin from the top level page soon after the iframe
+    // is created.
+    window.addEventListener('message', (event) => {
+        const data = event.data;
+
+        if (data.uuid && data.topLevelOrigin) {
+            // Set topLevelOrigin so that iframe monetization events can be stored under this origin
+            // and store any payment events that occured before receiving the topLevelOrigin.
+            topLevelOrigin = data.topLevelOrigin;
+            for (const monetizationPaymentEvent of monetizationPaymentEvents) {
+                storeDataIntoAkitaFormat(monetizationPaymentEvent, AKITA_DATA_TYPE.PAYMENT, topLevelOrigin);
+            }
+            monetizationPaymentEvents = [];
+
+            const iframeUuid = data.uuid;
+            // Let the top level page know that the iframe has receieved the uuid
+            webBrowser.runtime.sendMessage({
+                iframeReceivedUuid: {
+                    iframeUuid: iframeUuid
+                }
+            });
+            trackIframePaymentPointer(iframeUuid);
+        }
+    });
+
+
+    /**
+     * Regularly check for payment pointer changes in the iframe. If the payment pointer changes,
+     * the top level page (./content_origin.js) is notified via ./background_script.js, which forwards
+     * the `webBrowser.runtime.sendMessage` iframePaymentPointerChange message.
+     *
+     * @param {string} iframeUuid the uuid given to the iframe by top level page.
+     */
+    function trackIframePaymentPointer(iframeUuid) {
+        let cachedPaymentPointer = null;
+
+        setInterval(async () => {
+            const paymentPointerInIframe = getPaymentPointerFromPage();
+
+            // If the payment pointer in iframe changes, send new payment pointer to content_origin.js
+            if (paymentPointerInIframe !== cachedPaymentPointer) {
+                webBrowser.runtime.sendMessage({
+                    iframePaymentPointerChange: {
+                        iframeUuid: iframeUuid,
+                        paymentPointer: paymentPointerInIframe
+                    }
+                });
+                cachedPaymentPointer = paymentPointerInIframe;
+            }
+        }, NEW_PAYMENT_POINTER_CHECK_RATE_MS);
+    }
+}

--- a/src/data/AkitaPaymentPointerData.js
+++ b/src/data/AkitaPaymentPointerData.js
@@ -6,7 +6,7 @@ class AkitaPaymentPointerData {
 	paymentPointer = null;
 
 	// The most recent time (UTC timestamp) when Akita validated the payment pointer
-	// For more info on payment pointer validation: see ../content_main.js, function isPaymentPointerValid
+	// For more info on payment pointer validation: see ../content_origin.js, function isPaymentPointerValid
 	validationTimestamp = null;
 
 	// The type of each entry in sentAssetsMap is: WebMonetizationAsset

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -19,10 +19,9 @@ let webBrowser = chrome ? chrome : browser;
  *
  * @param {Object} data Data to store. May be null if no data included.
  * @param {AKITA_DATA_TYPE} typeOfData The type of param data, should be one of AKITA_DATA_TYPE.
+ * @param {string} origin The origin of the page storing the data. Defaults to window.location.origin.
  */
-async function storeDataIntoAkitaFormat(data, typeOfData) {
-	const origin = window.location.origin;
-
+async function storeDataIntoAkitaFormat(data, typeOfData, origin=window.location.origin) {
 	// Start getting originList asynchronously
 	const originListPromise = getOriginList();
 


### PR DESCRIPTION
Closes #82 

# Design Notes
The design for iframe web monetization tracking was outlined in #82, as discussed with @sharon-wang (and ❤️'d by @thejustinwalsh). Iframe web monetization tracking in Akita works as follow:

- Following [the spec](https://webmonetization.org/docs/api/), only iframes with the allow="monetization" attribute will count as monetized. If the iframe does not have this attribute, or the attribute is programmatically removed, the iframe will not be counted as being monetized. 
  - NOTE: It is technically possible for a provider to send payments to an iframe without the allow="monetization" attribute. In this case, this PR tracks web monetization events even if the iframe does not have allow="monetization" because users will probably want to know if they are streaming payment even if it is not spec compliant, but I wouldn't expect that to happen
- iframe monetization and time spent are tracked as part of the top-level page's AkitaOriginData.
  - A page is considered monetized by akita (and therefore the user's visit and time spent on the page is considered monetized) if it contains a valid payment pointer in a monetization meta tag, OR if any of the iframes on the page contain a valid payment pointer in a monetization meta tag.
  - Visits to, and time spent on, iframes are NOT tracked separately from the top level page. 
  - iframe web monetization events are stored under the top level page's origin, NOT under the iframe's origin.
  - This avoids the problem of worrying about how payment is split between iframes on the page.
- Nested monetized iframes are not supported by this PR (nested iframes are iframes in iframes). 
  - The spec does not specifically address nested iframes. 
  - [Coil does not support nested monetized iframes](https://github.com/coilhq/web-monetization-projects/pull/415).
- ~A new field called iframeSrcOrigin will be added to AkitaPaymentPointerData to keep track of the origin of payment pointers inside of iframes.~ (actually not necessary right now, I will discuss with @sharon-wang if this should be added)

For example, https://defold.itch.io/climberz only contains monetization within an iframe (the iframe contains a web game). This is how it appears in Akita:
<img src="https://user-images.githubusercontent.com/11082236/103377068-97acc280-4a9b-11eb-9718-370f8a3dcb39.png" height="400" alt="A screenshot of Akita displaying monetization info for defold.itch.io, a site with a monetized iframe">
Note that the iframe's origin is https://v6p9d9t4.ssl.hwcdn.net/html/2866116/Climberz/index.html, but that origin is not tracked nor is it shown in the UI.


# Implementation Notes
`src/content_main.js` has been split into three content scripts and moved to a new folder `src/content_scripts/`
- **content_origin.js** handles time and visit tracking for the top level page. content_origin.js decides if the page is monetized based on the payment pointers on the page and in iframes on the page.
- **content_general.js** runs both at the top level page (alongside content_origin.js), and in iframes (alongside content_iframe.js); it handles forwarding web monetization events into akita events.
- **content_iframe.js** runs inside of each iframe and tracks and notifies content_origin.js of payment pointer changes in the iframe via the `webBrowser.runtime` message channel. Each content_iframe.js in each iframe is assigned a uuid from content_origin.js via postMessage so that content_origin.js can know which iframe the script is associated with when the script sends messages.

`manifest.json` includes these content scripts in a specific order: `content_shared.js` must be included before both `content_main.js` and `content_iframe.js` because it initializes constants and starts tracking monetization events, and `content_main.js` must be included before `content_iframe.js` because it sets a flag `window.isTopLevel` which lets `content_iframe.js` not run the code it contains if it is in the top level page.

Note that `webBrowser.runtime.sendMessage` is used by `content_iframe.js` to send payment pointers when they change to the top level page instead of `postMessage` because the messages it sends cannot be accessed by the page, so it should be a little safer. `postMessage` must be used for sending uuids to iframes because the uuids must be sent directly to the iframe element so content_main.js knows which iframe it assigned the uuid.

# Testing Notes
- Tested on https://defold.itch.io/climberz
- Tested on https://www.youtube.com/watch?v=sApKXmwhg4g&amp%3Bab_channel=Simmer.io&ab_channel=Simmer.io
- Tested on https://esse-dev.github.io/a-web-monetization-story/
- Tested on https://dev.to/esse-dev/akita-get-involved-in-web-monetization-with-or-without-the-price-tag-cd8