### PR TITLE
Update code injection to best practice, remove tabs permission, and change version to 1.0.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name":"Akita",
-	"version":"0.1.0",
+	"version":"1.0.0",
 	"manifest_version": 2,
 	"description":"Get involved in Web Monetization with or without the price tag",
 	"icons": {
@@ -9,7 +9,6 @@
 		"128": "assets/icon_128x128.png"
 	},
 	"permissions":[
-		"tabs",
 		"storage"
 	],
 	"background": {
@@ -39,6 +38,7 @@
 			"all_frames":true
 		}
 	],
+	"web_accessible_resources": ["src/page_inject_script.js"],
 	"browser_action": {
 		"default_icon": "assets/icon_unmonetized.png",
 		"default_popup": "src/popup/popup.html",

--- a/src/content_scripts/content_general.js
+++ b/src/content_scripts/content_general.js
@@ -13,24 +13,14 @@ const PAYMENT_POINTER_VALIDATION_RATE_MS = 1000 * 60 * 60; // 1 hour
  * reference: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#Content_script_environment
  *			  https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
  * So we must inject some code into the JavaScript context of the current tab in order to
- * access the document.monetization object. We inject code using a script element:
+ * access the document.monetization object. We inject code using a script element with
+ * `chrome.extension.getURL` as recommended by google chrome developers:
+ * https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/
  */
 const scriptEl = document.createElement('script');
-scriptEl.text = `
-	if (document.monetization) {
-		document.monetization.addEventListener('monetizationstart', (event) => {
-			document.dispatchEvent(new CustomEvent('akita_monetizationstart', { detail: event.detail }));
-		});
-
-		document.monetization.addEventListener('monetizationprogress', (event) => {
-			document.dispatchEvent(new CustomEvent('akita_monetizationprogress', { detail: event.detail }));
-		});
-
-		document.monetization.addEventListener('monetizationstop', (event) => {
-			document.dispatchEvent(new CustomEvent('akita_monetizationstop', { detail: event.detail }));
-		});
-	}
-`;
+scriptEl.src = chrome.extension.getURL('src/page_inject_script.js');
+(document.head||document.documentElement).appendChild(scriptEl);
+scriptEl.onload = () => scriptEl.parentNode.removeChild(scriptEl);
 document.body.appendChild(scriptEl);
 
 /**

--- a/src/page_inject_script.js
+++ b/src/page_inject_script.js
@@ -1,0 +1,13 @@
+if (document.monetization) {
+    document.monetization.addEventListener('monetizationstart', (event) => {
+        document.dispatchEvent(new CustomEvent('akita_monetizationstart', { detail: event.detail }));
+    });
+
+    document.monetization.addEventListener('monetizationprogress', (event) => {
+        document.dispatchEvent(new CustomEvent('akita_monetizationprogress', { detail: event.detail }));
+    });
+
+    document.monetization.addEventListener('monetizationstop', (event) => {
+        document.dispatchEvent(new CustomEvent('akita_monetizationstop', { detail: event.detail }));
+    });
+}


### PR DESCRIPTION
Part of #73 

We now inject code using a script element in `content_general.js` with `chrome.extension.getURL` as recommended by [google chrome developers](https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/) in their latest manifest best practices info ([more info on the possible code injection methods on stackoverflow]( https://stackoverflow.com/questions/9515704/use-a-content-script-to-access-the-page-context-variables-and-functions)).

I'll note that in my research I found that Google recommends migrating to manifest v3 soon (we are currently on v2), but not all fields of the v3 manifest are yet supported in Chrome (only in Chrome Dev or Chrome Canary). But migration should be fairly easy when we want to, mainly we just need to move CORS fetch requests to the background script.

Also Akita's version is now 1.0.0 in the manifest in preparation for the Chrome Web Store submission 🎉