### PR TITLE
Fix visit tracking and add locking for storing data

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -236,12 +236,9 @@ function getPercentTimeSpentAtOriginOutOfTotal(originData, originStats) {
  * @return {Number} The percent of visits to the origin out of total visits.
  */
 function getPercentVisitsToOriginOutOfTotal(originData, originStats) {
-	if (!originData || !originStats) return 0;
+	if (!originData || !originStats || originStats.totalVisits === 0) return 0;
 
-	const visitsToOrigin = originData.originVisitData.numberOfVisits;
-	const totalVisits = originStats.totalVisits;
-
-	return toPercent(visitsToOrigin / totalVisits);
+	return toPercent(originData.originVisitData.numberOfVisits / originStats.totalVisits);
 }
 
 /**
@@ -252,12 +249,9 @@ function getPercentVisitsToOriginOutOfTotal(originData, originStats) {
  * @return {Number} The percent of monetized origin time spent.
  */
 function getMonetizedTimeSpentPercent(originStats) {
-	if (!originStats) return 0;
+	if (!originStats || originStats.totalTimeSpent === 0) return 0;
 
-	const totalMonetizedTimeSpent = originStats.totalMonetizedTimeSpent;
-	const totalTimeSpent = originStats.totalTimeSpent;
-
-	return toPercent(totalMonetizedTimeSpent / totalTimeSpent);
+	return toPercent(originStats.totalMonetizedTimeSpent / originStats.totalTimeSpent);
 }
 
 /**

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -20,7 +20,7 @@
 		<p id="info-container">
 			You’ve spent <strong id="monetized-time-data" style="font-size: 18px;">0 hours</strong> on monetized sites,
 			which is <strong id="monetized-percent-data" style="font-size: 18px;">0%</strong> of your time online.
-			In total, <span id="monetized-sent-text" style="font-size: 18px;">you’ve streamed</span> <span id="monetized-sent-data"><strong>0XRP</strong></span>.
+			<span id="monetized-sent-text" style="font-size: 18px;">Tabulating sent payment...</span><span id="monetized-sent-data"><strong></strong></span>
 		</p>
 		<div id="sites-need-love-container" style="display: none;">
 			<h1 class="tooltip">These monetized sites could use ♥️</h1>


### PR DESCRIPTION
Fixes: #101

Visit tracking was broken for sites that have delayed monetization events, such as adapted sites like YouTube and sites that enable monetization via iframes.

Now, we register a visit in `originStats` for every page visited and only increment the `originData` monetized visits once we know that the site is monetized.

In collaboration with @vezwork, locking has been added for storing data. During my testing, I noticed that data was getting overwritten, since many asynchronous requests to store to browser storage can occur at the same time. To ensure that data stores do not run over each other, locking around the data storing is needed so that writing to local browser storage occurs sequentially.

Even with this locking addition, we think there might be some errors with storing between tab switches. This is because saving data to browser storage is happening on a per-origin basis, but the data being stored is to the same place in browser storage, so there may be issues with losing/overwriting data. Opened https://github.com/esse-dev/akita/issues/103 to start discussion about this.