### PR TITLE
Use 'engagement' in place of 'involvement' in Akita descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Software License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Assets License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 
-A browser extension that gives you insight into your involvement with [Web Monetization](https://webmonetization.org/).
+A browser extension that gives you insight into your engagement with [Web Monetization](https://webmonetization.org/).
 
 Akita presents your top visited monetized sites, how much time you’re spending on them, and how much you're contributing (or could contribute) to them.
 
@@ -51,7 +51,7 @@ Otherwise, if the site does not have monetization enabled, then the icon will ap
 <img src="assets/demo_unmon.svg" alt="Monetization Not Enabled Akita Icon" height="100px">
 
 ### Akita Main View
-Our browser extension helps you see the top monetized sites you visit and your involvement with Web Monetization at-a-glance.
+Our browser extension helps you see the top monetized sites you visit and your engagement with Web Monetization at-a-glance.
 
 Here's a screenshot of what Akita looks like if you're using a Web Monetization provider:
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"name":"Akita",
 	"version":"1.0.0",
 	"manifest_version": 2,
-	"description":"Get involved in Web Monetization with or without the price tag",
+	"description":"Insight into your engagement with Web Monetization",
 	"icons": {
 		"16": "assets/icon_16x16.png",
 		"48": "assets/icon_48x48.png",

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -46,7 +46,7 @@
 	<div style="height: 100px; width: 100%; background: #FFF27B;"></div>
 	<div style="height: 100px; width: 100%; background: #9F88FC;"></div>
 
-	<!-- INTRO SLIDSHOW SECTION -->
+	<!-- INTRO SLIDESHOW SECTION -->
 	<section id="intro-carousel">
 		<div id="carousel">
 			<div class="carousel-slide">
@@ -55,7 +55,7 @@
 					style="height:170px;filter: drop-shadow(5px 5px 0px black);">
 				</object>
 				<h2>Welcome to Akita!</h2>
-				<p>Akita gives you insight into your involvement with Web Monetization by showing you Monetization information about the websites you visit.</p>
+				<p>Akita gives you insight into your engagement with Web Monetization by showing you Monetization information about the websites you visit.</p>
 				<p>Our goal with Akita is to increase Web Monetization understanding and awareness. Thank you! ~<a href="https://dev.to/esse-dev">esse-dev</a></p>
 			</div>
 			<div class="carousel-slide">


### PR DESCRIPTION
As mentioned in #73, using 'engagement' feels more welcoming than 'involvement', so we'd like to use 'engagement' in our Akita descriptions going forward.

I'll also update our repo description to use 'engagement'.