### PR TITLE
Remove dateOfFirstVisit and dateOfMostRecentVisit and update example data

### DIFF
--- a/examples/example_data.json
+++ b/examples/example_data.json
@@ -35,8 +35,6 @@
 			"originVisitData":{
 				"monetizedTimeSpent": 8731882,
 				"numberOfVisits": 3,
-				"dateOfFirstVisit": "2020-05-01",
-				"dateOfMostRecentVisit": "2020-06-02"
 			},
 			"paymentPointerMap":{
 				"$ilp.uphold.com/24HhrUGG7ekn":{
@@ -57,8 +55,6 @@
 			"originVisitData":{
 				"monetizedTimeSpent": 4723893,
 				"numberOfVisits": 2,
-				"dateOfFirstVisit": "2020-05-15",
-				"dateOfMostRecentVisit": "2020-05-27"
 			},
 			"paymentPointerMap":{
 				"$spsp.coil.com/twitch/nasa":{
@@ -89,8 +85,6 @@
 			"originVisitData":{
 				"monetizedTimeSpent": 4567890218492,
 				"numberOfVisits": 300,
-				"dateOfFirstVisit": "2020-01-01",
-				"dateOfMostRecentVisit": "2020-06-02"
 			},
 			"paymentPointerMap":{
 				"$ilp.uphold.com/DWhyhLRG7E4Q":{

--- a/examples/example_data.json
+++ b/examples/example_data.json
@@ -4,27 +4,27 @@
 	"originList": [
 		"https://dev.to",
 		"https://www.twitch.tv",
-		"https://sdog.netlify.app"
+		"https://esse-dev.github.io/a-web-monetization-story/"
 	],
 	"originStats": {
 		"totalTimeSpent": 1834971294872194719204821,
-		"totalMonetizedTimeSpent": 194719204821,
-		"totalVisits": 500,
+		"totalMonetizedTimeSpent": 316034933,
+		"totalVisits": 538,
 		"totalSentAssetsMap": {
 			"XRP": {
-				"amount": 74289471,
+				"amount": 10041906693,
 				"assetScale":9,
 				"assetCode":"XRP"
 			},
 			"USD": {
-				"amount": 26862,
+				"amount": 3728743927,
 				"assetScale":9,
-				"assetCode":"XRP"
+				"assetCode":"USD"
 			},
 			"CAD": {
-				"amount": 324824,
+				"amount": 32482892884,
 				"assetScale":9,
-				"assetCode":"XRP"
+				"assetCode":"CAD"
 			}
 		}
 	},
@@ -33,17 +33,17 @@
 			"origin":"https://dev.to",
 			"faviconSource": "https://dev-to.s3.us-east-2.amazonaws.com/favicon.ico",
 			"originVisitData":{
-				"monetizedTimeSpent": 8731882,
+				"monetizedTimeSpent": 37287439,
 				"numberOfVisits": 3,
 			},
 			"paymentPointerMap":{
 				"$ilp.uphold.com/24HhrUGG7ekn":{
 					"paymentPointer":"$ilp.uphold.com/24HhrUGG7ekn",
 					"sentAssetsMap":{
-						"XRP":{
-							"amount":16505,
+						"USD":{
+							"amount":3728743927,
 							"assetScale":9,
-							"assetCode":"XRP"
+							"assetCode":"USD"
 						}
 					}
 				}
@@ -53,15 +53,15 @@
 			"origin":"https://www.twitch.tv",
 			"faviconSource": "https://static.twitchcdn.net/assets/favicon-16-2d5d1f5ddd489ee10398.png",
 			"originVisitData":{
-				"monetizedTimeSpent": 4723893,
-				"numberOfVisits": 2,
+				"monetizedTimeSpent": 23510297,
+				"numberOfVisits": 6,
 			},
 			"paymentPointerMap":{
 				"$spsp.coil.com/twitch/nasa":{
 					"paymentPointer":"$spsp.coil.com/twitch/nasa",
 					"sentAssetsMap":{
 						"XRP":{
-							"amount":5351,
+							"amount":2320012974,
 							"assetScale":9,
 							"assetCode":"XRP"
 						}
@@ -71,7 +71,7 @@
 					"paymentPointer":"$spsp.coil.com/twitch/xqcow",
 					"sentAssetsMap":{
 						"XRP":{
-							"amount":11442,
+							"amount":7721893719,
 							"assetScale":9,
 							"assetCode":"XRP"
 						}
@@ -80,20 +80,20 @@
 			}
 		},
 		{
-			"origin":"https://sdog.netlify.app",
-			"faviconSource": "https://sharonwang.netlify.app/favicon.ico",
+			"origin":"https://esse-dev.github.io/a-web-monetization-story/",
+			"faviconSource": "https://esse-dev.github.io/a-web-monetization-story/assets/auden.svg",
 			"originVisitData":{
-				"monetizedTimeSpent": 4567890218492,
+				"monetizedTimeSpent": 255237197,
 				"numberOfVisits": 300,
 			},
 			"paymentPointerMap":{
-				"$ilp.uphold.com/DWhyhLRG7E4Q":{
-					"paymentPointer":"$ilp.uphold.com/DWhyhLRG7E4Q",
+				"$$ilp.uphold.com/aEYQyH47UYPY":{
+					"paymentPointer":"$ilp.uphold.com/aEYQyH47UYPY",
 					"sentAssetsMap":{
-						"XRP":{
-							"amount":13502,
+						"CAD":{
+							"amount":32482892884,
 							"assetScale":9,
-							"assetCode":"XRP"
+							"assetCode":"CAD"
 						}
 					}
 				}

--- a/src/data/AkitaOriginVisitData.js
+++ b/src/data/AkitaOriginVisitData.js
@@ -6,14 +6,10 @@
  * Visit data includes:
  *   - amount of time spent at origin since using Akita (in milliseconds)
  *   - number of visits recorded in Akita
- *   - date of first visit recorded in Akita (format: YYYY-MM-DD)
- *   - date of most recent visit recorded in Akita (format: YYYY-MM-DD)
  */
 class AkitaOriginVisitData {
 	monetizedTimeSpent = 0; // time in milliseconds
 	numberOfVisits = 0;
-	dateOfFirstVisit = "";
-	dateOfMostRecentVisit = "";
 
 	/**
 	 * This function takes an object with the same properties as AkitaOriginVisitData,
@@ -30,8 +26,6 @@ class AkitaOriginVisitData {
 			newOriginVisitData = new AkitaOriginVisitData();
 			newOriginVisitData.monetizedTimeSpent = akitaOriginVisitDataObject.monetizedTimeSpent;
 			newOriginVisitData.numberOfVisits = akitaOriginVisitDataObject.numberOfVisits;
-			newOriginVisitData.dateOfFirstVisit = akitaOriginVisitDataObject.dateOfFirstVisit;
-			newOriginVisitData.dateOfMostRecentVisit = akitaOriginVisitDataObject.dateOfMostRecentVisit;
 		}
 
 		return newOriginVisitData;
@@ -51,43 +45,5 @@ class AkitaOriginVisitData {
 	 */
 	updateVisitData() {
 		this.numberOfVisits += 1;
-		this.dateOfMostRecentVisit = this.getCurrentDateAsYYYYMMDD();
-
-		if (this.dateOfFirstVisit === "") {
-			// We haven't already stored the date of first visit
-			this.dateOfFirstVisit = this.dateOfMostRecentVisit;
-		}
-	}
-
-	/**
-	 * Return the current date formatted as YYYY-MM-DD.
-	 *
-	 * @return {Number} The current date.
-	 */
-	getCurrentDateAsYYYYMMDD() {
-		const DASH = '-';
-		const currentDate = new Date();
-		const currentYear = currentDate.getFullYear();
-		const currentMonth = this.formatNumberAsDateString(currentDate.getMonth() + 1); // +1 since month is 0-indexed in javascript :(
-		const currentDay = this.formatNumberAsDateString(currentDate.getDay());
-
-		const dateString = currentYear + DASH + currentMonth + DASH + currentDay;
-
-		return dateString;
-	}
-
-	/**
-	 * Prepend the number with a zero if its value is between
-	 * zero and ten, so that it is compatible in date strings.
-	 *
-	 * e.g. If number = 6, return "06"
-	 *
-	 * @param {Number} number Value to format as a date number.
-	 * @return The formatted number.
-	 */
-	formatNumberAsDateString(number) {
-		if (number < 10 && number > 0) {
-			return "0" + number;
-		}
 	}
 }


### PR DESCRIPTION
`dateOfFirstVisit` and `dateOfMostRecentVisit` are not used by Akita and there are no plans to use this information, so we should not store it. Also there was something broken with the date calculation anyways (showing something like `2020-undefined-01`).

We could also get rid of `AkitaOriginVisitData` and store the visit data directly in the `AkitaOriginData`, opened https://github.com/esse-dev/akita/issues/109 for this. Getting rid of it now (right before Chrome store submission) would be a risky change, so deferring it to later.

Also updated our example data so the numbers make more sense and to fix some typos.