### PR TITLE
Add Privacy Policy, and links to AkitaFeedback@gmail.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ We'd like to add beginner issues and tag our issues so that it's easier for
 those interested to join our effort. Stay tuned for that!_
 
 Here's how you can get involved:
+
 - [Open an Issue](#open-an-issue)
 - [Contribute Code](#contribute-code)
 	- [Implement Your Changes](#implement-your-changes)
@@ -13,7 +14,7 @@ Here's how you can get involved:
 
 ## Open an Issue
 
-Akita Issue List: https://github.com/esse-dev/akita/issues
+Akita Issue List: [https://github.com/esse-dev/akita/issues](https://github.com/esse-dev/akita/issues)
 
 Please let us know if Akita isn't working for you! Feel free to create a new
 issue or comment on an existing one. We'd love it if you could include as much
@@ -24,12 +25,17 @@ We're always looking to make Akita better, so definitely drop us a Feature Reque
 if you have any ideas brewing!
 
 Issue Templates you can choose from:
+
 - 📄 [Create New Blank Issue](https://github.com/esse-dev/akita/issues/new?assignees=&labels=&template=blank-issue.md&title=)
 - 🐞 [Create New Bug Report](https://github.com/esse-dev/akita/issues/new?assignees=&labels=bug&template=bug_report.md&title=%5BBUG%5D)
 - 💡 [Create New Feature Request](https://github.com/esse-dev/akita/issues/new?assignees=&labels=enhancement&template=feature_request.md&title=%5BFEATURE+REQUEST%5D)
 
 ## Contribute Code
-	 
+
+Before contributing code to Akita please read [Akita's Privacy Policy](docs/PrivacyPolicy.md) so you
+can help us ensure data privacy for Akita users! If you make any changes that affect user data,
+please review the Privacy Policy to check if any updates should be made to it alongside your changes.
+
 ### Implement Your Changes
 1. Fork Akita and clone your fork
 2. Create a new branch with a name that reflects your changes
@@ -52,6 +58,9 @@ review it and may provide suggestions or feedback before approving and merging.
 Thanks so much for contributing to Akita! ❤️
 
 ## When in doubt, don't hesitate to bark at us 🐶
+
+- Email
+	- [AkitaFeedback@gmail.com](mailto:AkitaFeedback@gmail.com)
 - Find us on DEV.to
 	- [esse-dev](https://dev.to/esse-dev)
 	- [Elliot](https://dev.to/elliot)

--- a/README.md
+++ b/README.md
@@ -119,9 +119,13 @@ The data collected by Akita is stored on your machine, in your browser's local s
 Your data stays in your hands: it is not backed up, shared, or uploaded anywhere.
 Therefore, if you uninstall the Akita browser extension, your data will be **permanently deleted** and will not be recoverable.
 
+For more info, check out [Akita's Privacy Policy](docs/PrivacyPolicy.md).
+
 ---
 
 ## Connect with Us
+- Email
+  - [AkitaFeedback@gmail.com](mailto:AkitaFeedback@gmail.com)
 - DEV
   - [esse-dev](https://dev.to/esse-dev)
   - [Elliot](https://dev.to/elliot)

--- a/docs/PrivacyPolicy.md
+++ b/docs/PrivacyPolicy.md
@@ -1,0 +1,117 @@
+# Akita Privacy Policy
+
+Last updated January 1st 2021.
+
+This Privacy Policy applies to the Akita Browser Extension developed by the contributors at
+[https://github.com/esse-dev/akita](https://github.com/esse-dev/akita). This Privacy Policy
+addresses the following questions:
+
+1. [What information does Akita collect?](#1-What-information-does-Akita-collect)
+2. [How does Akita use the information it collects?](#2-How-does-Akita-use-the-information-it-collects)
+3. [What information does Akita share? (none)](#3-What-information-does-Akita-share)
+4. [How long does Akita retain your data?](#4-How-long-does-Akita-retain-your-data)
+5. [Which browser permissions does Akita use?](#5-Which-browser-permissions-does-Akita-use)
+6. [Where can I find Akita's source code?](#6-Where-can-I-find-Akitas-source-code)
+
+The intention of Akita's developers is to create a browser extension which is respectful of your
+data and privacy. Akita's developers prioritize data privacy and actively work to avoid data related
+bugs, but it is still possible for bugs to arise that lead to lost, leaked, or stolen data. By
+installing the Akita browser extension you certify that you understand and accept all
+responsibilities and risks associated with using the extension, including possible lost, leaked, or
+stolen data; and you do not hold Akita's developers liable or responsible for anything resulting
+from your use of the extension.
+
+If you have any questions or concerns about Akita's Privacy Policy, please reach out to the
+developers using one of the following methods:
+
+- Send an email to Akita's developers at [AkitaFeedback@gmail.com](mailto:AkitaFeedback@gmail.com)
+- [Submit an issue on Akita's GitHub code repository](https://github.com/esse-dev/akita/issues/new?assignees=&labels=&template=blank-issue.md&title=)
+- [Join the Akita Discord server](https://discord.gg/psyNbWW)
+
+## 1. What information does Akita collect?
+
+Akita collects the following data:
+
+- The amount of time you've spent on each website you’ve visited;
+- A count of your visits to websites;
+- Data in the
+  ["monetization" meta tag](https://webmonetization.org/docs/explainer#add-meta-tag-to-website-header)
+  found in the metadata of the websites you visit, such as a
+  [Payment Pointer](https://paymentpointers.org/);
+- Whether or not requests sent by Akita to Payment Pointer URLs are successful (to ensure that the
+  Payment Pointers are valid); and
+- The currencies and amounts of payments you’ve sent using Web Monetization providers via Payment
+  Pointers on websites (as reported by the [Web Monetization API](https://webmonetization.org/) to
+  the browser).
+
+This information and any insights drawn from it are stored in the local browser storage of your
+device. Data collected by Akita is not backed up, shared or uploaded anywhere.
+
+You can view an example of the raw data collected by Akita
+[here](https://github.com/esse-dev/akita/blob/master/examples/example_data.json).
+
+## 2. How does Akita use the information it collects?
+
+Akita's single purpose is to give you insight into your browsing data in the context of Web
+Monetization, so that you can better understand how you are engaging with Web Monetization while you
+browse the web. To provide you with useful information, Akita makes calculations with the data it
+collects to generate numbers such as totals, percentages and estimates. More specifically, Akita
+shows you the following collected and calculated information in the Akita extension popup:
+
+- The sites that you’ve spent the most time on which have Web Monetization enabled;
+  - And for each of these sites:
+    - How much time you’ve spent on the site while engaging with Web Monetized content;
+    - The percentage of the time you've spent on the site while engaging with Web Monetized content
+      out of the total time you’ve spent on websites i.e.
+      `100 * (monetized time you've spent on the site) / (total time you've spent on websites)`;
+    - The number of visits to the site where you engaged with Web Monetized content;
+    - The percentage of the number of visits to the site where you engaged with Web Monetized
+      content out of your total number of visits to websites i.e.
+      `100 * (number of monetized visits to site) / (total visits to websites)`; and
+    - How much payment you've sent using Web Monetization providers via Payment Pointers on the site
+      (as reported by the Web Monetization API to the browser), as well as the currencies of the
+      payments.
+  - How much time you’ve spent on sites while engaging with Web Monetized content;
+  - The percentage of the time you've spent on sites while engaging with Web Monetized content out
+    of the total time you’ve spent on websites i.e.
+    `100 * (monetized time you've spent on websites) / (total time you've spent on websites)`;
+  - How much payment you've sent using Web Monetization providers via Payment Pointers on websites
+  (as reported by the Web Monetization API to the browser), as well as the currencies of the
+  payments; and
+- Web Monetized sites that you've spent less time on or sent less payment to compared to other Web
+  Monetized sites you've visited (shown under the heading "Sites that could use some ❤️").
+
+Additionally, the Akita Browser Extension adheres to the
+[Chrome Web Store User Data Policy](https://developer.chrome.com/docs/webstore/program_policies/),
+including its [Limited Use](https://developer.chrome.com/docs/webstore/program_policies#limited_use)
+requirements regarding user data.
+
+## 3. What information does Akita share?
+
+None. All information that Akita collects is stored in the web browser's local storage, so it is
+only accessible by those who have access to your computer. Akita does not upload or send your data
+anywhere. It stores your data for the single purpose of showing your data to you in the extension
+popup. If you uninstall the Akita browser extension from your browser, your data will be
+**permanently deleted** and will not be recoverable.
+
+## 4. How long does Akita retain your data?
+
+Akita stores your data locally on your computer for as long as you have the Akita extension
+installed. Akita does not back up your data nor create any copies of it. You can permanently delete
+your data at any time by uninstalling Akita.
+
+## 5. Which browser permissions does Akita use?
+
+Akita uses the "storage" browser permission to store collected data locally on your computer. Akita
+also has "host permissions" on all `http` and `https` sites, so that it can collect data relevant to
+Web Monetization on the sites you visit. Akita does not collect data when you open files or
+non-website pages in your web browser. To view the permissions Akita lists in its browser extension
+manifest, go [here](https://github.com/esse-dev/akita/blob/master/manifest.json).
+
+## 6. Where can I find Akita's source code?
+
+Akita is open source, which means that Akita's code is publicly available. Akita accepts
+[code contributions](https://github.com/esse-dev/akita/blob/master/CONTRIBUTING.md) and
+[feedback](https://github.com/esse-dev/akita/issues/new/choose) from the GitHub community. All
+versions of Akita's source can be found in
+[Akita's GitHub code repository](https://github.com/esse-dev/akita).

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -139,10 +139,14 @@
 				<ul style="line-height: normal;">
 					<li>your time spent and number of visits on all websites,</li>
 					<li>the <a href="https://paymentpointers.org/">Payment Pointers</a> present on the websites you visit,</li>
-					<li>and the currency and amount of payments streamed to Payment Pointers via Web Monetization.</li>
+					<li>and the currencies and amounts of payments you’ve sent via Payment Pointers on websites</li>
 				</ul>
-				<p>The data collected by Akita is stored locally on your computer, so all of this data stays in your hands.</p>
-				<p>If you uninstall the Akita browser extension, your data will be <strong>permanently deleted</strong> and will not be recoverable.</p>
+				<p>
+					The data collected by Akita is stored locally on your computer. If you uninstall
+					the Akita browser extension, your data will be <strong>permanently deleted</strong>
+					and will not be recoverable.
+				</p>
+				<p>For more info, check out <a href="https://github.com/esse-dev/akita/blob/master/docs/PrivacyPolicy.md">Akita's Privacy Policy</a>.</p>
 			</div>
 		</div>
 		<div id="intro-exit">skip</div>


### PR DESCRIPTION
Part of #73

Adds a Privacy Policy as required by [Privacy Policy & Secure Handling Requirements - Chrome Developers](https://developer.chrome.com/docs/webstore/user_data/). The privacy policy addresses the following questions: 

- What information does Akita collect?
- How does Akita use the information it collects?
- What information does Akita share? (none)
- How long does Akita retain your data?
- Which browser permissions does Akita use?
- Where can I find Akita's source code?

Additionally updates links and references to the Privacy Policy in README.md, CONTRIBUTING.md, and in the last tutorial slide in the extension popup.

Additionally adds contact links to our new email AkitaFeedback@gmail.com to README.md and CONTRIBUTING.md

This PR was co-authored by @sharon-wang .