### PR TITLE
Update package script to include needed subdirectories in assets

### DIFF
--- a/packageAkita.sh
+++ b/packageAkita.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-zip -r -q akita.zip assets/*.png assets/*.svg src manifest.json LICENSE
+zip -r -q akita.zip \
+    assets/external/webmonetization/wm-icon-animated.svg \
+    assets/icons/* \
+    assets/tutorial/* \
+    assets/*.svg \
+    assets/*.png \
+    src \
+    manifest.json \
+    LICENSE


### PR DESCRIPTION
Assets were getting left out of the package since the script was not updated when the asset directory structure was updated.

This adds only the necessary assets/directories for the extension (leaves out images we use exclusively in our GitHub documentation, for example).

Perhaps in the future there's a better directory structure we can use that simplifies the script.