### PR TITLE
Update installation and license documentation

### DIFF
--- a/docs/InstallAkita.md
+++ b/docs/InstallAkita.md
@@ -1,33 +1,39 @@
 # Installing Akita
 
-Akita has been tested in Mozilla Firefox and Google Chrome. Instructions to install on these browsers is provided below. We hope to release Akita to browser extension stores in the near future.
+Akita has been tested in Mozilla Firefox and Chromium-based browsers (i.e. Chrome, Brave, Microsoft Edge, etc.). Instructions to install Akita on these browsers is provided below.
 
 Our license information can be found [here](LicenseInfo.md) and our license/copyright notices can be found in [LICENSE](../LICENSE).
 
-## Table of Contents
-  - [Step 1: Download Akita Source](#step-1-download-akita-source)
-  - [Step 2, Option 1: Install Akita in Your Browser from Source](#step-2-option-1-install-akita-in-your-browser-from-source)
-  - [Step 2, Option 2: Install Akita in Your Browser from Package](#step-2-option-2-install-akita-in-your-browser-from-package)
+## Installing Akita from Browser Extension/Add-On Stores
 
----
+- ### **Chrome Web Store**: [https://chrome.google.com/webstore/detail/akita/phcipgphomfgkenfmjnbmajdiejnlmgg](https://chrome.google.com/webstore/detail/akita/phcipgphomfgkenfmjnbmajdiejnlmgg)
+- ### **Firefox Browser Add-ons**: _Coming soon..._
+- ### **Microsoft Edge Add-ons**: _Coming soon..._
 
-## Step 1: Download Akita Source
+## Installing Akita Manually (From Source or Package)
+
+### Step 1: Download Akita Source
 From your preferred directory, run the command:
 
 `git clone https://github.com/esse-dev/akita.git`
 
 Note the path to the newly created `akita` directory.
 
-## Step 2, Option 1: Install Akita in Your Browser from Source
+### Step 2, Option 1: Install Akita in Your Browser from Source
 
-### Installing Akita in Google Chrome
-1. In your Chrome address bar, type in `chrome://extensions/`. Press enter.
-2. Ensure "Developer mode" is toggled "ON" in the top right corner of the page.
+#### Installing Akita in Chromium-Based Browsers (i.e. Chrome, Brave, Microsoft Edge, etc.)
+1. In the browser address bar, type in `<BROWSER_NAME>://extensions/`. Press enter.
+    - `<BROWSER_NAME>` is `chrome` for Google Chrome, `brave` for Brave Browser, `edge` for Microsoft Edge, etc.
+    - example: `brave://extensions/`
+2. Ensure "Developer mode" is toggled "ON"
+    - For Chrome and Brave, this is in the _top right_ corner of the page.
+    - For Edge, this is in the _bottom left_ of the page.
 3. Click on "Load unpacked". A system file selection window should open.
 4. In the selection window, navigate to the `akita` directory and select it.
 5. Akita is now installed - you should see the Akita extension icon in your browser bar!!
+    - Note: Some browsers may not pin the extension to the browser bar by default. You may need to pin it manually.
 
-### Installing Akita in Mozilla Firefox
+#### Installing Akita in Mozilla Firefox
 1. In your Firefox address bar, type in `about:debugging#/runtime/this-firefox`. Press enter.
 2. Click on "Load Temporary Add-on...". A system file selection window should open.
 3. In the selection window, navigate to the `akita` directory and select any file in it.
@@ -37,20 +43,25 @@ Some notes for Firefox:
 - Since Akita is installed as a temporary add-on, it only stays until you restart Firefox.
 - If you're feeling extra crafty, you can also install Akita using [web-ext](https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/).
 
-## Step 2, Option 2: Install Akita in Your Browser from Package
+### Step 2, Option 2: Install Akita in Your Browser from Package
 
-### Package Akita into a .zip
+#### Package Akita into a .zip
 1. Make sure you have the command-line tools `bash` and `zip` installed.
 2. From the akita directory, run `bash ./packageAkita.sh`.
 3. The resulting file akita.zip can be loaded into Firefox and Chrome.
 
-### To Install `akita.zip` in Google Chrome
-1. In your Chrome address bar, type in `chrome://extensions/`. Press enter.
-2. Ensure "Developer mode" is toggled "ON" in the top right corner of the page.
+#### To Install `akita.zip` in Chromium-Based Browsers (i.e. Chrome, Brave, Microsoft Edge, etc.)
+1. In the browser address bar, type in `<BROWSER_NAME>://extensions/`. Press enter.
+    - `<BROWSER_NAME>` is `chrome` for Google Chrome, `brave` for Brave Browser, `edge` for Microsoft Edge, etc.
+    - example: `brave://extensions/`
+2. Ensure "Developer mode" is toggled "ON"
+    - For Chrome and Brave, this is in the _top right_ corner of the page.
+    - For Edge, this is in the _bottom left_ of the page.
 3. From your file explorer, drag `akita.zip` into the browser window.
 4. Akita is now installed - you should see the Akita extension icon in your browser bar!!
+    - Note: Some browsers may not pin the extension to the browser bar by default. You may need to pin it manually.
 
-### To Install `akita.zip` in Mozilla Firefox
+#### To Install `akita.zip` in Mozilla Firefox
 1. In your Firefox address bar, type in `about:debugging#/runtime/this-firefox`. Press enter.
 2. Click on "Load Temporary Add-on...". A system file selection window should open.
 3. In the selection window, select `akita.zip`

--- a/docs/LicenseInfo.md
+++ b/docs/LicenseInfo.md
@@ -2,7 +2,11 @@
 
 We want to make it easy for anyone to get involved with Akita, so we've licensed our project under two permissive licenses.
 
-We've chosen the MIT License for our software (i.e. code/documentation) and the Creative Commons Attribution 4.0 International Public License (CC BY 4.0) for any of the assets we create (generally found in [assets](../assets) and any subdirectories).
+We've chosen the MIT License for our software (i.e. code/documentation) and the Creative Commons Attribution 4.0 International Public License (CC BY 4.0) for any of the assets we create (generally found in [assets](../assets) and any subdirectories, other than those found in the [assets/external](../assets/external) directory).
+
+Assets in the [assets/external](../assets/external) directory are assets from another source or repository, which may not have been created by us. Please refer to the per-asset/per-source license information in [assets/external](../assets/external) for more details.
+
+---
 
 Licenses can be a bit intimidating, but we've chosen the ones we think make it easiest for you to leverage Akita.
 
@@ -15,4 +19,4 @@ _The short explanations below are meant to make the licenses more understandable
 
 For our copyright and license notices, please refer to our [LICENSE](../LICENSE) file.
 
-Essentially, just include our [LICENSE](../LICENSE) file and link to this repo if you end up using our code, documentation or assets. :)
+Essentially, just include our [LICENSE](../LICENSE) file and link to this repo if you end up using our code, documentation or assets. :) If you want to use any assets in the [assets/external](../assets/external) directory, you should do a bit more reading on the per-asset/per-source license information, as they likely have different licensing from the rest of our project.


### PR DESCRIPTION
Updated some of our documentation:

`LicenseInfo.md` -- preview: https://github.com/sharon-wang/akita/blob/updatedocs/docs/LicenseInfo.md
- Mention external assets license info
- Closes: #115 

`InstallAkita.md` -- preview: https://github.com/sharon-wang/akita/blob/updatedocs/docs/InstallAkita.md
- Add Chrome Web Store installation link
- Change Chrome installation instructions to Chromium-based browsers