### PR TITLE
Move class fields into constructor to avoid Firefox add-on errors

### DIFF
--- a/src/data/AkitaOriginData.js
+++ b/src/data/AkitaOriginData.js
@@ -9,18 +9,13 @@
  * See ./example_data.json to see example instances of AkitaOriginData.
  */
 class AkitaOriginData {
-	origin = null;
-	faviconSource = null;
-
-	// The type of each entry in paymentPointerMap is: AkitaPaymentPointerData
-	paymentPointerMap = {};
-
-	// The type of originVisitData is: AkitaOriginVisitData
-	originVisitData = null;
-
-	constructor(origin) {
-		this.origin = origin;
+	constructor(originString) {
+		this.origin = originString;
 		this.originVisitData = new AkitaOriginVisitData();
+		this.faviconSource = null;
+
+		// The type of each entry in paymentPointerMap is: AkitaPaymentPointerData
+		this.paymentPointerMap = {};
 	}
 
 	/**

--- a/src/data/AkitaOriginData.js
+++ b/src/data/AkitaOriginData.js
@@ -9,10 +9,10 @@
  * See ./example_data.json to see example instances of AkitaOriginData.
  */
 class AkitaOriginData {
-	constructor(originString) {
+	constructor(originString, faviconSourceString = null, originVisitData = new AkitaOriginVisitData()) {
 		this.origin = originString;
-		this.originVisitData = new AkitaOriginVisitData();
-		this.faviconSource = null;
+		this.faviconSource = faviconSourceString;
+		this.originVisitData = originVisitData;
 
 		// The type of each entry in paymentPointerMap is: AkitaPaymentPointerData
 		this.paymentPointerMap = {};
@@ -27,19 +27,16 @@ class AkitaOriginData {
 	 * @return {AkitaOriginData} the input object as an instance of the AkitaOriginData class.
 	 */
 	static fromObject(akitaOriginDataObject) {
-		const newOriginData = new AkitaOriginData(akitaOriginDataObject.origin);
-		newOriginData.faviconSource = akitaOriginDataObject.faviconSource;
+		const newOriginData = new AkitaOriginData(
+			akitaOriginDataObject.origin,
+			akitaOriginDataObject.faviconSource,
+			AkitaOriginVisitData.fromObject(akitaOriginDataObject.originVisitData)
+		);
 
 		for (const paymentPointer in akitaOriginDataObject.paymentPointerMap) {
 			newOriginData.paymentPointerMap[paymentPointer] = AkitaPaymentPointerData.fromObject(
 				akitaOriginDataObject.paymentPointerMap[paymentPointer]
 			);
-		}
-
-		// Add deserialization for originVisitData
-		const originVisitDataDeserialized = AkitaOriginVisitData.fromObject(akitaOriginDataObject.originVisitData);
-		if (originVisitDataDeserialized) {
-			newOriginData.originVisitData = originVisitDataDeserialized;
 		}
 
 		return newOriginData;

--- a/src/data/AkitaOriginStats.js
+++ b/src/data/AkitaOriginStats.js
@@ -11,10 +11,10 @@
  *   - map of totalSentAssets, with an entry for each currency
  */
 class AkitaOriginStats {
-	constructor() {
-		this.totalTimeSpent = 0;
-		this.totalMonetizedTimeSpent = 0;
-		this.totalVisits = 0;
+	constructor(totalTimeSpentNumber = 0, totalMonetizedTimeSpentNumber = 0, totalVisitsNumber = 0) {
+		this.totalTimeSpent = totalTimeSpentNumber;
+		this.totalMonetizedTimeSpent = totalMonetizedTimeSpentNumber;
+		this.totalVisits = totalVisitsNumber;
 
 		// The type of each entry in totalSentAssetsMap is: WebMonetizationAsset
 		this.totalSentAssetsMap = {};
@@ -29,11 +29,11 @@ class AkitaOriginStats {
 	 * @return {AkitaOriginStats} the input object as an instance of the AkitaOriginStats class.
 	 */
 	static fromObject(akitaOriginStats) {
-		const newAkitaOriginStats = new AkitaOriginStats();
-
-		newAkitaOriginStats.totalTimeSpent = akitaOriginStats.totalTimeSpent;
-		newAkitaOriginStats.totalMonetizedTimeSpent = akitaOriginStats.totalMonetizedTimeSpent;
-		newAkitaOriginStats.totalVisits = akitaOriginStats.totalVisits;
+		const newAkitaOriginStats = new AkitaOriginStats(
+			akitaOriginStats.totalTimeSpent,
+			akitaOriginStats.totalMonetizedTimeSpent,
+			akitaOriginStats.totalVisits
+		);
 
 		for (const assetCode in akitaOriginStats.totalSentAssetsMap) {
 			newAkitaOriginStats.totalSentAssetsMap[assetCode] = WebMonetizationAsset.fromObject(

--- a/src/data/AkitaOriginStats.js
+++ b/src/data/AkitaOriginStats.js
@@ -11,12 +11,14 @@
  *   - map of totalSentAssets, with an entry for each currency
  */
 class AkitaOriginStats {
-	totalTimeSpent = 0;
-	totalMonetizedTimeSpent = 0;
-	totalVisits = 0;
+	constructor() {
+		this.totalTimeSpent = 0;
+		this.totalMonetizedTimeSpent = 0;
+		this.totalVisits = 0;
 
-	// The type of each entry in totalSentAssetsMap is: WebMonetizationAsset
-	totalSentAssetsMap = {};
+		// The type of each entry in totalSentAssetsMap is: WebMonetizationAsset
+		this.totalSentAssetsMap = {};
+	}
 
 	/**
 	 * This function takes an object with the same properties as AkitaOriginStats,

--- a/src/data/AkitaOriginVisitData.js
+++ b/src/data/AkitaOriginVisitData.js
@@ -8,8 +8,12 @@
  *   - number of visits recorded in Akita
  */
 class AkitaOriginVisitData {
-	monetizedTimeSpent = 0; // time in milliseconds
-	numberOfVisits = 0;
+	constructor() {
+		// time in milliseconds
+		this.monetizedTimeSpent = 0;
+
+		this.numberOfVisits = 0;
+	}
 
 	/**
 	 * This function takes an object with the same properties as AkitaOriginVisitData,

--- a/src/data/AkitaOriginVisitData.js
+++ b/src/data/AkitaOriginVisitData.js
@@ -8,11 +8,11 @@
  *   - number of visits recorded in Akita
  */
 class AkitaOriginVisitData {
-	constructor() {
+	constructor(monetizedTimeSpentNumber = 0, numberOfVisitsNumber = 0) {
 		// time in milliseconds
-		this.monetizedTimeSpent = 0;
+		this.monetizedTimeSpent = monetizedTimeSpentNumber;
 
-		this.numberOfVisits = 0;
+		this.numberOfVisits = numberOfVisitsNumber;
 	}
 
 	/**
@@ -24,13 +24,10 @@ class AkitaOriginVisitData {
 	 * @return {AkitaOriginVisitData} the input object as an instance of the AkitaOriginVisitData class.
 	 */
 	static fromObject(akitaOriginVisitDataObject) {
-		let newOriginVisitData = null;
-
-		if (akitaOriginVisitDataObject) {
-			newOriginVisitData = new AkitaOriginVisitData();
-			newOriginVisitData.monetizedTimeSpent = akitaOriginVisitDataObject.monetizedTimeSpent;
-			newOriginVisitData.numberOfVisits = akitaOriginVisitDataObject.numberOfVisits;
-		}
+		const newOriginVisitData = new AkitaOriginVisitData(
+			akitaOriginVisitDataObject.monetizedTimeSpent,
+			akitaOriginVisitDataObject.numberOfVisits
+		);
 
 		return newOriginVisitData;
 	}

--- a/src/data/AkitaPaymentPointerData.js
+++ b/src/data/AkitaPaymentPointerData.js
@@ -3,17 +3,15 @@
  * sent to that payment pointer. An asset is some amount of a currencies like USD, CAD or XRP.
  */
 class AkitaPaymentPointerData {
-	paymentPointer = null;
+	constructor(paymentPointerString) {
+		this.paymentPointer = paymentPointerString;
 
-	// The most recent time (UTC timestamp) when Akita validated the payment pointer
-	// For more info on payment pointer validation: see ../content_origin.js, function isPaymentPointerValid
-	validationTimestamp = null;
+		// The most recent time (UTC timestamp) when Akita validated the payment pointer
+		// For more info on payment pointer validation: see ../content_origin.js, function isPaymentPointerValid
+		this.validationTimestamp = null;
 
-	// The type of each entry in sentAssetsMap is: WebMonetizationAsset
-	sentAssetsMap = {};
-
-	constructor(paymentPointer) {
-		this.paymentPointer = paymentPointer;
+		// The type of each entry in sentAssetsMap is: WebMonetizationAsset
+		this.sentAssetsMap = {};
 	}
 
 	/**

--- a/src/data/AkitaPaymentPointerData.js
+++ b/src/data/AkitaPaymentPointerData.js
@@ -3,12 +3,13 @@
  * sent to that payment pointer. An asset is some amount of a currencies like USD, CAD or XRP.
  */
 class AkitaPaymentPointerData {
-	constructor(paymentPointerString) {
+	constructor(paymentPointerString, validationTimestampNumber = null) {
 		this.paymentPointer = paymentPointerString;
 
 		// The most recent time (UTC timestamp) when Akita validated the payment pointer
 		// For more info on payment pointer validation: see ../content_origin.js, function isPaymentPointerValid
-		this.validationTimestamp = null;
+		// This is a Number, but is initialized to null to signify that the payment pointer has not yet been validated
+		this.validationTimestamp = validationTimestampNumber;
 
 		// The type of each entry in sentAssetsMap is: WebMonetizationAsset
 		this.sentAssetsMap = {};
@@ -23,14 +24,17 @@ class AkitaPaymentPointerData {
 	 * @return {AkitaPaymentPointerData} the input object as an instance of the AkitaPaymentPointerData class.
 	 */
 	static fromObject(akitaPaymentPointerDataObject) {
-		const newPaymentPointerData = new AkitaPaymentPointerData(akitaPaymentPointerDataObject.paymentPointer);
-		newPaymentPointerData.validationTimestamp = akitaPaymentPointerDataObject.validationTimestamp;
+		const newPaymentPointerData = new AkitaPaymentPointerData(
+			akitaPaymentPointerDataObject.paymentPointer,
+			akitaPaymentPointerDataObject.validationTimestamp
+		);
 
 		for (const assetCode in akitaPaymentPointerDataObject.sentAssetsMap) {
 			newPaymentPointerData.sentAssetsMap[assetCode] = WebMonetizationAsset.fromObject(
 				akitaPaymentPointerDataObject.sentAssetsMap[assetCode]
 			);
 		}
+
 		return newPaymentPointerData;
 	}
 

--- a/src/data/WebMonetizationAsset.js
+++ b/src/data/WebMonetizationAsset.js
@@ -11,10 +11,10 @@
  *	 235 * 10**(-2) = 2.35
  */
 class WebMonetizationAsset {
-	constructor(assetCode) {
-		this.assetCode = assetCode;
-		this.amount = 0;
-		this.assetCode = null;
+	constructor(assetCodeString, amountNumber = 0, assetScaleNumber = 0) {
+		this.assetCode = assetCodeString;
+		this.amount = amountNumber;
+		this.assetScale = assetScaleNumber;
 	}
 
 	/**
@@ -26,10 +26,11 @@ class WebMonetizationAsset {
 	 * @return {WebMonetizationAsset} the input object as an instance of the WebMonetizationAsset class.
 	 */
 	static fromObject(webMonetizationAsset) {
-		const newWebMonetizationAsset = new WebMonetizationAsset(webMonetizationAsset.assetCode);
-
-		newWebMonetizationAsset.amount = webMonetizationAsset.amount;
-		newWebMonetizationAsset.assetScale = webMonetizationAsset.assetScale;
+		const newWebMonetizationAsset = new WebMonetizationAsset(
+			webMonetizationAsset.assetCode,
+			webMonetizationAsset.amount,
+			webMonetizationAsset.assetScale
+		);
 
 		return newWebMonetizationAsset;
 	}

--- a/src/data/WebMonetizationAsset.js
+++ b/src/data/WebMonetizationAsset.js
@@ -11,12 +11,10 @@
  *	 235 * 10**(-2) = 2.35
  */
 class WebMonetizationAsset {
-	amount = 0;
-	assetScale = 0;
-	assetCode = null;
-
 	constructor(assetCode) {
 		this.assetCode = assetCode;
+		this.amount = 0;
+		this.assetCode = null;
 	}
 
 	/**


### PR DESCRIPTION
Defining class fields is invalid in older versions of JavaScript, which Firefox seems to test for in its add-on scanning. Moving the fields into the class's constructor avoids these errors. This resolves "Errors: Declaring class properties outside of the constructor." of https://github.com/esse-dev/akita/issues/65.

Some minor refactoring to the constructors and `fromObject()` was done for better consistency.

Testing:
- Firefox add-on scan: errors no longer reported/seen
- Chromium-based browsers: no regressions