### PR TITLE
Replace usages of innerHTML with innerText or by appending elements

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -153,60 +153,6 @@ function getEstimatedPaymentForTimeInUSD(timeSpent) {
 }
 
 /***********************************************************
- * Amount of Payment Streamed (Sent Assets)
- ***********************************************************/
-
-/**
- * Convert the provided sentAssetsMap to a string.
- * Example output: "20.20CAD, 0.67XRP and 123.45 USD"
- *
- * @param {Map<String, Number>} sentAssetsMap A map containing the sent asset amounts,
- * with the currency as the key (String) and the sent amount as the value (Number).
- * @param {Number} decimalPoints The AkitaOriginData to calculate sent assets for.
- * @return {String} The sent assets formatted as a string.
- */
-function getSentAssetsMapAsString(sentAssetsMap, decimalPoints) {
-	let sentAssetsString = ``;
-
-	if (sentAssetsMap) {
-		let entriesToStringify = sentAssetsMap.size;
-
-		for (const [currency, amount] of sentAssetsMap.entries()) {
-			let amountSent = amount.toFixed(decimalPoints);
-
-			// No need to display the amount if it's effectively zero
-			if (parseFloat(amountSent) === 0) {
-				continue;
-			}
-
-			let amountSentString = `<strong>${amountSent}<span style="font-size: 12px;">${currency}</span></strong>`;
-
-			// There's only one entry in the map
-			if (sentAssetsMap.size === 1) {
-				sentAssetsString = amountSentString;
-				break;
-			}
-
-			// There's more than one entry in the map
-			if (entriesToStringify >= 3) {
-				// There are at least 3 entries to stringify, so we'll use a comma to separate the entries
-				sentAssetsString += `${amountSentString}, `;
-			} else if ((sentAssetsMap.size > 1) && (entriesToStringify === 1)) {
-				// This is the entry left to stringify, so use 'and'
-				sentAssetsString += ` and ${amountSentString}`;
-			} else {
-				// There's a single entry remaining in the map
-				sentAssetsString += `${amountSentString}`;
-			}
-
-			entriesToStringify -= 1;
-		}
-	}
-
-	return sentAssetsString;
-}
-
-/***********************************************************
  * Various data retrieval functions
  ***********************************************************/
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -131,6 +131,17 @@ section {
 	z-index: 1;
 }
 
+#top-site-detail a {
+	display: block;
+	color: black;
+	text-decoration: underline;
+	margin-bottom: 20px;
+}
+
+#top-site-detail p {
+	margin-bottom: 20px;
+}
+
 #circle-container {
 	height: 180px;
 	width: 100%;


### PR DESCRIPTION
Fixes part 4 _(Warnings: Use of .innerHTML with dynamic content.)_ of #65.

## Changes

- Replace usages of `element.innerHTML` either with:
  - `.innerText` (when the element only contains text) or
  - using new HTML helper functions to programmatically create and insert html elements into the element (when the element contains other elements). These HTML helper function are located at the bottom of `popup.js`.
- Renames `getSentAssetsMapAsString` to `getSentAssetsMapAsEls` and moves it from `main.js` to `popup.js` (since it now uses the HTML helper functions).
- Add css styling to `a` and `p` elements in top site detail to make up for styling previously added by `.innerHTML`.

## Testing Notes

- Test links and text in Chrome, Edge, and Firefox.
- No functionality or appearances should have changed.
- Please ensure text and links display correctly in the following areas and circumstances:
  - when no sites have been visited, on the main page,
  - when monetized sites have been visited without a provider, on the main page,
  - when monetized sites have been visited with a provider, on the main page,
  - top site detail without a provider, and
  - top site detail with a provider.