### PR TITLE
Add https://*/* permission to avoid fetch error in Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
 		"128": "assets/icons/icon_128x128.png"
 	},
 	"permissions":[
-		"storage"
+		"storage",
+		"https://*/*"
 	],
 	"background": {
 		"scripts": ["src/background_script.js"]


### PR DESCRIPTION
The monetization icon was broken in Firefox (not indicating if a site is monetized). This is because we had removed the `<all_urls>` permission some time ago, but Firefox needs at least the `https` permission in the manifest since we are making fetch requests to HTTPS endpoints (to validate payment pointers). This change fixes #120.

_Firefox is unable to successfully fetch (results in `"TypeError: NetworkError when attempting to fetch resource"`) without permission to https. We fetch SPSP endpoints to check that they are valid, so that we know the payment pointers are legitimate. The monetization icon will not be set if we cannot validate the payment pointer._

This permission doesn't seem to be necessary on Chromium-based browsers.

**NOTE** that if upon resubmission to Chrome/Edge we get rejected because of the HTTPS permission (and assuming Firefox approves of the submission), then we will have to separately package the extension for Chromium and Firefox with the permission removed for Chromium and included for Firefox.