### PR TITLE
Fix favicon loading so it does not block data storage

### DIFF
--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -107,7 +107,7 @@ async function updateAkitaData(originData, data, typeOfData, isMonetizedData) {
 			updateTimeSpent(originData, originStats, data, isMonetizedData);
 			break;
 		case AKITA_DATA_TYPE.ORIGIN_FAVICON: // Only for a monetized origin
-			await updateOriginFavicon(originData, data);
+			updateOriginFavicon(originData, data);
 			break;
 		default:
 			// console.log("invalid data type provided");

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -384,25 +384,26 @@ function createTopSiteDetailEls(originData, originStats) {
 				textEl(`Crunching time spent numbers...`)
 			]);
 		}
+	} else {
+		setContentOfEl(timeSpentEl, [textEl(`Crunching time spent numbers...`)]);
 	}
 
-	// Set visit count text
-	let visitCountText = ``;
 	const visitCount = originData.originVisitData.numberOfVisits;
-	if (visitCount === 0) {
-		// Don't set the visit count text
-	} else if (visitCount === 1) {
-		visitCountText = `${visitCount} time`;
-	} else {
-		visitCountText = `${visitCount} times`;
-	}
+
+	// Set visit count text
 	let visitCountEl = paragraphEl();
-	if (visitCountText !== ``) {
+	if (visitCount > 0) {
 		const percentVisits = getPercentVisitsToOriginOutOfTotal(originData, originStats);
 		if (percentVisits > 0) {
+			let timeText;
+			if (visitCount > 1) {
+				timeText = `times`;
+			} else {
+				timeText = `time`;
+			}
 			setContentOfEl(visitCountEl, [
 				textEl(`You've visited `),
-				strongEl(visitCountText),
+				strongEl(`${visitCount} ${timeText}`),
 				textEl(`, which is `),
 				strongEl(`${percentVisits}%`),
 				textEl(` of your total website visits.`)
@@ -412,6 +413,10 @@ function createTopSiteDetailEls(originData, originStats) {
 				textEl(`Counting up visits...`)
 			]);
 		}
+	} else {
+		setContentOfEl(visitCountEl, [
+			textEl(`Counting up visits...`)
+		]);
 	}
 
 	// Set payment data text


### PR DESCRIPTION
Fixes #137 [BUG] Top Site Detail shows "undefined" after visiting a site for a very short period of time

## Changes

- Removes the `await` from the `updateOriginFavicon` function call in the `updateAkitaData` function definition in `storage.js`. This `await` was causing an issue because the `updateOriginFavicon` function awaits a fetch on the favicon image which may take an indefinite time to complete, blocking the function and in-turn indefinitely blocking data storage in the `updateAkitaData` function.
- Adds text display handling for when `visitCount`or `timeSpent` are 0. 