### PR TITLE
Fix the iframe uuid case where two akitas are installed

### DIFF
--- a/src/content_scripts/content_origin.js
+++ b/src/content_scripts/content_origin.js
@@ -470,12 +470,16 @@ webBrowser.runtime.onMessage.addListener((message) => {
 	if (message.iframeReceivedUuid) {
 		const { iframeUuid } = message.iframeReceivedUuid;
 		const iframe = iframeUuidMap.get(iframeUuid);
-		iframesWithUuids.add(iframe);
+		if (iframe) {
+			iframesWithUuids.add(iframe);
+		}
 	}
 	if (message.iframePaymentPointerChange) {
 		const { iframeUuid, paymentPointer } = message.iframePaymentPointerChange;
 		const iframe = iframeUuidMap.get(iframeUuid);
-		paymentPointerIframeMap.set(iframe, paymentPointer);
+		if (iframe) {
+			paymentPointerIframeMap.set(iframe, paymentPointer);
+		}
 	}
 });
 


### PR DESCRIPTION
Fixes #140 

## Changes
- Adds `undefined` checks for iframe messages containing unexpected uuids not corresponding to a known iframe. Unexpected uuids only occur when the user has multiple akita extensions installed and they both assign uuids to the iframes which the other akita extension instance does not know about; in this case the extension tries to look up the iframe corresponding to the uuid and gets `undefined`, leading to incorrect behaviour because the code assumed that no unexpected uuids would occur. 