### PR TITLE
Add Web Monetization Community Forem link and fix tooltip bubbles

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,5 @@ For more info, check out [Akita's Privacy Policy](docs/PrivacyPolicy.md).
   - [esse_dev](https://twitter.com/esse_dev)
   - [Elliot](https://twitter.com/elliotokay)
   - [Sharon](https://twitter.com/_sharonwang)
+- LinkedIn
+  - [esse dev](https://www.linkedin.com/company/esse-dev)

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -245,7 +245,7 @@ section {
 .tooltip-bubble-right {
 	margin-right: -10px;
 	margin-left: 5px;
-	right: 0;
+	right: 10px;
 }
 
 .tooltip:hover + .tooltip-bubble-left, .tooltip:hover + .tooltip-bubble-right {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -44,7 +44,7 @@
 				<div class="tooltip-bubble-left tooltip-love">These are sites which you visit often, but do not spend much time on.</div>
 			</div>
 			<div id="no-provider-resources-container" class="link-grid" style="margin-top: 25px;">
-				<a href="https://dev.to/esse-dev/how-can-you-support-websites-without-having-to-deal-with-annoying-ads-3lmb" class="tooltip" style="background: #C47233;">How can you support websites without having to deal with annoying ads?</a>
+				<a href="https://community.webmonetization.org/" class="tooltip" style="background: #C47233;">Check out what's going on in the Web Monetization Community</a>
 				<a href="https://coil.com/creator/how-to-monetize" class="tooltip" style="background: #C47233;">Monetize your own website or creative content with Coil</a>
 			</div>
 		</div>
@@ -153,10 +153,10 @@
 					<a href="https://developers.coil.com/resources" class="tooltip" style="background: #42D2B8;">Coil Developers Web Monetization Resources</a>
 					<div class="tooltip-bubble-right" style="top: 367px;">Guide for developers and creators</div>
 
-					<a href="https://coil.com/creator/how-to-monetize" class="tooltip" style="background: #9F88FC;">Monetize your own website or creative content with Coil</a>
-					<div class="tooltip-bubble-left" style="top: 479px;">Monetize your work</div>
-					<a href="https://dev.to/esse-dev/how-can-you-support-websites-without-having-to-deal-with-annoying-ads-3lmb" class="tooltip" style="background: #FFF27B;">How can you support websites without having to deal with annoying ads?</a>
-					<div class="tooltip-bubble-right" style="top: 479px;">Why does Web Monetization matter?</div>
+					<a href="https://community.webmonetization.org/" class="tooltip" style="background: #9F88FC;">Web Monetization Community Forem</a>
+					<div class="tooltip-bubble-left" style="top: 454px;">Updates in the Web Monetization Community</div>
+					<a href="https://coil.com/creator/how-to-monetize" class="tooltip" style="background: #FFF27B;">Monetize your own website or creative content with Coil</a>
+					<div class="tooltip-bubble-right" style="top: 454px;">Monetize your website or content</div>
 				</div>
 			</div>
 			<div class="carousel-slide">


### PR DESCRIPTION
Closes https://github.com/esse-dev/akita/issues/136.

## Changes

- Add WM Community Forem link (https://community.webmonetization.org/) to the main akita view (for non-WM provider users) and to the tutorial resources view (for all users)
- Fix tooltip bubble placement for the bottom row in the tutorial resources view
- Add esse dev LinkedIn page to README (unrelated change, but throwing it in 😅)

## Preview

_(screenshots taken on hover)_

![image](https://user-images.githubusercontent.com/25834218/115129678-1a5b7e00-9fb6-11eb-9f58-59d160f06181.png)

![image](https://user-images.githubusercontent.com/25834218/115129685-26474000-9fb6-11eb-9b1c-385cf577b2ee.png)