### PR TITLE
Fix originData favicon path not being stored

### DIFF
--- a/src/data/AkitaOriginData.js
+++ b/src/data/AkitaOriginData.js
@@ -110,11 +110,11 @@ class AkitaOriginData {
 	}
 
 	/**
-	 * Store the favicon source.
+	 * Set the favicon source.
 	 *
 	 * @param {String} faviconPath The url of the origin's favicon.
 	 */
-	storeOriginFavicon(faviconPath) {
+	setOriginFavicon(faviconPath) {
 		this.faviconSource = faviconPath;
 	}
 

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -269,10 +269,7 @@ async function isFetchStatusOk(url) {
 	let response = await fetch(url);
 
 	if (response) {
-		if (200 === response.status) {
-			return true;
-		} else {
-			return false;
+		return (200 === response.status);
 		}
 	}
 }

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -236,7 +236,7 @@ function updateTimeSpent(originData, originStats, recentTimeSpent, isMonetizedTi
  * path on the given origin is made with the input path.
  *
  * @param {String} path A path to convert to an absolute path, or check that it is already an absolute path.
- * @param {String} origin If the path is relative, This param is he origin which the path is
+ * @param {String} origin If the path is relative, this param is he origin which the path is
  * relative to. Not used if the path is absolute.
  * @returns {String} The input path as an absolute path.
  */

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -8,6 +8,7 @@ const AKITA_DATA_TYPE = {
 	'TIME_SPENT': 2,
 	'ORIGIN_FAVICON': 3
 };
+const VALID_AKITA_DATA_TYPE_VALUES = Object.values(AKITA_DATA_TYPE);
 
 const ORIGIN_NAME_LIST_KEY = 'originList';
 const ORIGIN_STATS_KEY = 'originStats';
@@ -83,7 +84,7 @@ async function storeDataIntoAkitaFormatNonMonetized(data, typeOfData) {
  * @param {Boolean} isMonetizedData Whether or not the data being stored is for a monetized origin.
  */
 async function updateAkitaData(originData, data, typeOfData, isMonetizedData) {
-	if (!Object.values(AKITA_DATA_TYPE).includes(typeOfData)) {
+	if (!VALID_AKITA_DATA_TYPE_VALUES.includes(typeOfData)) {
 		throw "invalid typeOfData passed to updateAkitaData";
 	}
 
@@ -268,10 +269,7 @@ function pathToAbsolutePath(path, origin) {
 async function isFetchStatusOk(url) {
 	let response = await fetch(url);
 
-	if (response) {
-		return (200 === response.status);
-		}
-	}
+	return (200 === response?.status);
 }
 
 /***********************************************************

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -122,7 +122,7 @@ async function updateAkitaData(originData, data, typeOfData, isMonetizedData) {
  *   - fetches the favicon to check if it is a valid favicon,
  *     - if the fetch is successful, the favicon is valid, so the origin's orginData favicon is set
  *     to the given favicon path,
- *     - if the fetch is unsuccessful the origin's originData favicon is set to "",
+ *     - if the fetch is unsuccessful, the origin's originData favicon is set to "",
  *   - finally, the updated originData is stored.
  *
  * Note: this function's implementation assumes that this origin's data has been created

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -128,7 +128,7 @@ async function updateAkitaData(originData, data, typeOfData, isMonetizedData) {
  * Note: this function's implementation assumes that the specified origin's data has been created
  * and stored prior to the critical section.
  *
- * @param {String} origin The origin which should have its corresponding originData favicon set.
+ * @param {String} origin The origin to set a favicon for.
  * @param {String} faviconPath The absolute or relative path to the origin's favicon.
  */
  async function storeOriginFavicon(origin, faviconPath) {

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -235,7 +235,7 @@ function updateTimeSpent(originData, originStats, recentTimeSpent, isMonetizedTi
  * is absolute, the input path is returned unchanged. If the input path is relative, an absolute
  * path on the given origin is made with the input path.
  *
- * @param {String} path A path which you want as an absolute path.
+ * @param {String} path A path to convert to an absolute path, or check that it is already an absolute path.
  * @param {String} origin If the path is relative, This param is he origin which the path is
  * relative to. Not used if the path is absolute.
  * @returns {String} The input path as an absolute path.

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -136,10 +136,10 @@ async function updateAkitaData(originData, data, typeOfData, isMonetizedData) {
 	const absoluteFaviconPath = pathToAbsolutePath(faviconPath, origin);
 	const isFaviconValid = await isFetchStatusOk(absoluteFaviconPath);
 
-	// Once/If the favicon resolves, store the originData with the favicon included:
+	// Once/If the favicon resolves, store the originData with the favicon included
 	const resolveLock = await acquireStoreLock();
 
-	// Get and update existing data for this origin.
+	// Get and update existing data for this origin
 	let originData = await loadOriginData(origin);
 	if (isFaviconValid) {
 		originData.setOriginFavicon(absoluteFaviconPath);

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -125,7 +125,7 @@ async function updateAkitaData(originData, data, typeOfData, isMonetizedData) {
  *     - if the fetch is unsuccessful, the origin's originData favicon is set to "",
  *   - finally, the updated originData is stored.
  *
- * Note: this function's implementation assumes that this origin's data has been created
+ * Note: this function's implementation assumes that the specified origin's data has been created
  * and stored prior to the critical section.
  *
  * @param {String} origin The origin which should have its corresponding originData favicon set.


### PR DESCRIPTION
Fixes #148

## Changes

- Renames `AkitaOriginData.storeOriginFavicon` to `AkitaOriginData.setOriginFavicon` (and all usages) to reflect that it updates the originData object rather than storing it in the browser's local storage.
- Removes the `updateOriginFavicon` function.
- Fixes #148 by adding a new function `storeOriginFavicon` in `storage.js` (Note that this function is not related to the renamed `AkitaOriginData.storeOriginFavicon` function)  which is called by `updateAkitaData` to asynchronously fetch, update, and store the favicon for an origin.

## Bug explanation

This bug is a regression introduced in #141.
This PR made it so that favicon fetching did not block storing originData. This resulted in a regression where the originData object was being updated after it had already been stored, meaning the updated originData object was never stored.

## Fix explanation

Fixing this issue requires introducing a new function `storeOriginFavicon` which fetches the favicon, and once/if the fetch resolves, updates and stores the originData safely using a lock.

## Fix demo image
![image](https://user-images.githubusercontent.com/11082236/119915990-a8217600-bf31-11eb-9219-94f67e491247.png)
