### PR TITLE
Update version in manifest.json to 1.1.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name":"Akita",
-	"version":"1.0.1",
+	"version":"1.1.1",
 	"manifest_version": 2,
 	"description":"Insight into your engagement with Web Monetization",
 	"icons": {


### PR DESCRIPTION
## Changes

- Updates the version in `manifest.json` to 1.1.1 to prepare for the v1.1.1-beta release (see [milestone 4](https://github.com/esse-dev/akita/milestone/4)).

## Notes
- I accidentally made a v1.1.0-beta release without updating the manifest.json, but you cannot delete release tags (easily, anyways) so we are just making a v1.1.1-beta release with the updated manifest.json to fix that problem.