### PR TITLE
Add Firefox add-on link to README and InstallAkita

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   Note, at the time of adding the Edge badge below, there is no officially documented API for retrieving the add on details, so the method from https://github.com/badges/shields/issues/4690#issuecomment-647573617 has been used.
 -->
 [![Available on Chrome Web Store](https://img.shields.io/chrome-web-store/v/phcipgphomfgkenfmjnbmajdiejnlmgg?color=brightgreen)](https://chrome.google.com/webstore/detail/akita/phcipgphomfgkenfmjnbmajdiejnlmgg)
+[![Available on Firefox Browser Add-ons](https://img.shields.io/amo/v/akita?color=blueviolet)](https://addons.mozilla.org/en-US/firefox/addon/akita/)
 [![Available on Microsoft Edge Add-ons](https://img.shields.io/badge/dynamic/json?label=edge%20add-ons&prefix=v&query=%24.version&url=https://microsoftedge.microsoft.com/addons/getproductdetailsbycrxid/halamaefcdjalhjgkbefalmhpnboncoc)](https://microsoftedge.microsoft.com/addons/detail/akita/halamaefcdjalhjgkbefalmhpnboncoc)
 
 A browser extension that gives you insight into your engagement with [Web Monetization](https://webmonetization.org/), part of [The Akita Project](https://akitaproject.site/).
@@ -58,6 +59,7 @@ Check out the instructions to install from source or package [here](docs/Install
 You can also install Akita from Browser Extension/Add-On Stores:
 
 - [Chrome Web Store](https://chrome.google.com/webstore/detail/akita/phcipgphomfgkenfmjnbmajdiejnlmgg)
+- [Firefox Browser Add-ons](https://addons.mozilla.org/en-US/firefox/addon/akita/)
 - [Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/akita/halamaefcdjalhjgkbefalmhpnboncoc)
 
 ---

--- a/docs/InstallAkita.md
+++ b/docs/InstallAkita.md
@@ -7,7 +7,7 @@ Our license information can be found [here](LicenseInfo.md) and our license/copy
 ## Installing Akita from Browser Extension/Add-On Stores
 
 - ### **Chrome Web Store**: [https://chrome.google.com/webstore/detail/akita/phcipgphomfgkenfmjnbmajdiejnlmgg](https://chrome.google.com/webstore/detail/akita/phcipgphomfgkenfmjnbmajdiejnlmgg)
-- ### **Firefox Browser Add-ons**: _Coming soon..._
+- ### **Firefox Browser Add-ons**: [https://addons.mozilla.org/en-US/firefox/addon/akita/](https://addons.mozilla.org/en-US/firefox/addon/akita/)
 - ### **Microsoft Edge Add-ons**: [https://microsoftedge.microsoft.com/addons/detail/akita/halamaefcdjalhjgkbefalmhpnboncoc](https://microsoftedge.microsoft.com/addons/detail/akita/halamaefcdjalhjgkbefalmhpnboncoc)
 
 ## Installing Akita Manually (From Source or Package)


### PR DESCRIPTION
Fixes: https://github.com/esse-dev/akita/issues/133

Adds the Firefox add on installation link https://addons.mozilla.org/en-US/firefox/addon/akita/ to our README and install instructions, and also adds a badge to our README for Firefox.

### Previews
- README: https://github.com/sharon-wang/akita/blob/addfirefoxbadge/README.md
- InstallAkita: https://github.com/sharon-wang/akita/blob/addfirefoxbadge/docs/InstallAkita.md

### Badge Preview
![image](https://user-images.githubusercontent.com/25834218/120400103-4420f800-c30b-11eb-948c-5e8e8e8227b9.png)
